### PR TITLE
release: v2.9.0

### DIFF
--- a/src/predefine/ReactHook.ts
+++ b/src/predefine/ReactHook.ts
@@ -1,5 +1,5 @@
-import { isNumber } from '@/utils/helper';
-import { forEach, mapItem, objectKeys, trueValue, undefinedValue } from '@/utils/variables';
+import { isNumber, noop } from '@/utils/helper';
+import { falseValue, forEach, mapItem, objectKeys, trueValue, undefinedValue } from '@/utils/variables';
 import { Dispatch, MutableRefObject, SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
 import { EffectRequestParams } from '~/typings';
 
@@ -18,6 +18,16 @@ export default {
     forEach(objectKeys(newVal), key => {
       states[key][1](newVal[key] as any);
     }),
+  wrap: (fn: (...args: any[]) => any, isAbort = falseValue) => {
+    // abort函数在react下需要使用同一个函数，否则会访问不到原abort函数
+    // 其他函数使用可以访问最新状态的同一个函数
+    if (!isAbort) {
+      const fnRef = useRef(noop as typeof fn);
+      setRef(fnRef, fn);
+      fn = (...args: any[]) => refCurrent(fnRef)(...args);
+    }
+    return useCallback(fn, []);
+  },
   effectRequest({
     handler,
     removeStates,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -185,6 +185,15 @@ interface StatesHook<S, E> {
   update: (newVal: Record<string, any>, state: Record<string, S>) => void;
 
   /**
+   * 包装send、abort等use hooks操作函数
+   * 这主要用于优化在react中，每次渲染都会生成新函数的问题，优化性能
+   * @param fn use hook操作函数
+   * @param isAbort 是否为abort函数，abort函数在react需要不同的处理
+   * @returns 包装后的操作函数
+   */
+  wrap?: (fn: (...args: any[]) => any, isAbort?: boolean) => (...args: any[]) => any;
+
+  /**
    * 控制执行请求的函数，此函数将在useRequest、useWatcher被调用时执行一次
    * 在useFetcher中的fetch函数中执行一次
    * 当watchedStates为空数组时，执行一次handleRequest函数


### PR DESCRIPTION
feat(react): optimize the handlers of use hooks in react with `useCallback`

and now, you can use send and abort directly in events, and don't worry about the performance in react

fix #141