### PR TITLE
fix: use abort() before request sent cause an exception when using useRequest (#314)

### DIFF
--- a/src/functions/createRequestState.ts
+++ b/src/functions/createRequestState.ts
@@ -177,7 +177,7 @@ export default function createRequestState<S, E, R, T, RC, RE, RH, UC extends Us
       }
       update(newStates, frontStates, hookInstance);
     }),
-    abort: memorize(() => hookInstance.m.abort(), trueValue),
+    abort: memorize(() => hookInstance.m?.abort(), trueValue),
 
     /**
      * 通过执行该方法来手动发起请求

--- a/src/functions/createRequestState.ts
+++ b/src/functions/createRequestState.ts
@@ -177,7 +177,7 @@ export default function createRequestState<S, E, R, T, RC, RE, RH, UC extends Us
       }
       update(newStates, frontStates, hookInstance);
     }),
-    abort: memorize(() => hookInstance.m?.abort(), trueValue),
+    abort: memorize(() => hookInstance.m && hookInstance.m.abort(), trueValue),
 
     /**
      * 通过执行该方法来手动发起请求

--- a/test/browser/hooks/vue/useRequest-http.spec.ts
+++ b/test/browser/hooks/vue/useRequest-http.spec.ts
@@ -224,6 +224,28 @@ describe('use useRequest hook to send GET with vue', function () {
     expect(error.value).toBe(err.error);
   });
 
+  test('abort request manually with abort function returns in useRequest(non-immediate)', async () => {
+    const alova = getAlovaInstance(VueHook, {
+      responseExpect: r => r.json()
+    });
+    const Get = alova.Get<string, Result<string>>('/will-never-request');
+    const { loading, data, error, abort, onError } = useRequest(Get, { immediate: false });
+    const errFn = jest.fn();
+    onError(errFn);
+
+    expect(loading.value).toBeFalsy();
+    expect(data.value).toBeUndefined();
+    expect(error.value).toBeUndefined();
+
+    // fix #314
+    expect(abort).not.toThrow();
+    expect(errFn).not.toHaveBeenCalled();
+
+    expect(loading.value).toBeFalsy();
+    expect(data.value).toBeUndefined();
+    expect(error.value).toBeUndefined();
+  });
+
   test('abort request manually with abort function in method instance', async () => {
     const alova = getAlovaInstance(VueHook, {
       resErrorExpect: error => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -181,7 +181,7 @@ type ResponsedHandlerRecord<S, E, RC, RE, RH> = {
 type HookType = 1 | 2 | 3;
 interface Hook {
   /** 最后一次请求的method实例 */
-  m: Method;
+  m?: Method;
 
   /** saveStatesFns */
   sf: ((frontStates: FrontRequestState) => void)[];


### PR DESCRIPTION
Fixing type annotations and adding an optional chaining (?.) operator. (close #314)