### PR TITLE
暴露instance 实例适用于动态更改MethodType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-error.log*
 .eslintcache
 /demo
 /design
+pnpm-lock.yaml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,8 @@
   "jest.autoRun": "off",
   "[svelte]": {
     "editor.defaultFormatter": "svelte.svelte-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alova",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alova",
-      "version": "2.20.2",
+      "version": "2.20.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alova",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "description": "Request strategy library for MVVM libraries such as Vue.js, React.js and Svelte.js",
   "main": "dist/alova.esm.js",
   "module": "dist/alova.esm.js",

--- a/src/alova.ts
+++ b/src/alova.ts
@@ -3,10 +3,11 @@ import {
   AlovaMethodConfig,
   AlovaOptions,
   MethodRequestConfig,
+  MethodType,
   RequestBody,
   StatesHook
 } from '~/typings';
-import Method, { typeDelete, typeGet, typeHead, typeOptions, typePatch, typePost, typePut } from './Method';
+import Method, { typeGet } from './Method';
 import globalLocalStorage from './predefine/globalLocalStorage';
 import { getStatesHook, newInstance } from './utils/helper';
 import myAssert from './utils/myAssert';
@@ -42,26 +43,48 @@ export class Alova<S, E, RC, RE, RH> {
       ...options
     };
   }
+
+  /**
+   * 暴露instance 实例适用于动态更改MethodType
+   * 例
+   *  const create = (data: Arg) => alova.Post('api/todo', data)
+   *  const update = (data: Arg) => alova.Put('api/todo', data)
+   *  const createOrUpdate = (data: Arg) => !!data?.id ? update(data) : create(data)
+   *  以下等于👆👆👆
+   *  const store = (data: Arg) => alova.instance({
+   *    url: 'api/todo',
+   *    type: ['POST', 'PUT'][Number(!!data?.id)],
+   *    data
+   *  })
+   */
+  instance<R, T = unknown>(options: {
+    url: string,
+    type: MethodType,
+    data?: RequestBody,
+    config?: AlovaMethodCreateConfig<R, T, RC, RH>
+  }) {
+    return newInstance(Method<S, E, R, T, RC, RE, RH>, options.type, this, options.url, options?.config, options?.data);
+  }
   Get<R, T = unknown>(url: string, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return newInstance(Method<S, E, R, T, RC, RE, RH>, typeGet, this, url, config);
+    return this.instance({ url, type: typeGet, config });
   }
   Post<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return newInstance(Method<S, E, R, T, RC, RE, RH>, typePost, this, url, config, data);
+    return this.instance({ url, type: typeGet, config, data });
   }
   Delete<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return newInstance(Method<S, E, R, T, RC, RE, RH>, typeDelete, this, url, config, data);
+    return this.instance({ url, type: typeGet, config, data });
   }
   Put<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return newInstance(Method<S, E, R, T, RC, RE, RH>, typePut, this, url, config, data);
+    return this.instance({ url, type: typeGet, config, data });
   }
   Head<R, T = unknown>(url: string, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return newInstance(Method<S, E, R, T, RC, RE, RH>, typeHead, this, url, config);
+    return this.instance({ url, type: typeGet, config });
   }
   Patch<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return newInstance(Method<S, E, R, T, RC, RE, RH>, typePatch, this, url, config, data);
+    return this.instance({ url, type: typeGet, config, data });
   }
   Options<R, T = unknown>(url: string, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return newInstance(Method<S, E, R, T, RC, RE, RH>, typeOptions, this, url, config);
+    return this.instance({ url, type: typeGet, config });
   }
 }
 

--- a/src/alova.ts
+++ b/src/alova.ts
@@ -66,25 +66,25 @@ export class Alova<S, E, RC, RE, RH> {
     return newInstance(Method<S, E, R, T, RC, RE, RH>, options.type, this, options.url, options?.config, options?.data);
   }
   Get<R, T = unknown>(url: string, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typeGet, config });
+    return this.instance<R, T>({ url, type: typeGet, config });
   }
   Post<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typePost, config, data });
+    return this.instance<R, T>({ url, type: typePost, config, data });
   }
   Delete<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typeDelete, config, data });
+    return this.instance<R, T>({ url, type: typeDelete, config, data });
   }
   Put<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typePut, config, data });
+    return this.instance<R, T>({ url, type: typePut, config, data });
   }
   Head<R, T = unknown>(url: string, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typeHead, config });
+    return this.instance<R, T>({ url, type: typeHead, config });
   }
   Patch<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typePatch, config, data });
+    return this.instance<R, T>({ url, type: typePatch, config, data });
   }
   Options<R, T = unknown>(url: string, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typeOptions, config });
+    return this.instance<R, T>({ url, type: typeOptions, config });
   }
 }
 

--- a/src/alova.ts
+++ b/src/alova.ts
@@ -7,7 +7,7 @@ import {
   RequestBody,
   StatesHook
 } from '~/typings';
-import Method, { typeGet } from './Method';
+import Method, { typeDelete, typeGet, typeHead, typeOptions, typePatch, typePost, typePut } from './Method';
 import globalLocalStorage from './predefine/globalLocalStorage';
 import { getStatesHook, newInstance } from './utils/helper';
 import myAssert from './utils/myAssert';
@@ -69,22 +69,22 @@ export class Alova<S, E, RC, RE, RH> {
     return this.instance({ url, type: typeGet, config });
   }
   Post<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typeGet, config, data });
+    return this.instance({ url, type: typePost, config, data });
   }
   Delete<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typeGet, config, data });
+    return this.instance({ url, type: typeDelete, config, data });
   }
   Put<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typeGet, config, data });
+    return this.instance({ url, type: typePut, config, data });
   }
   Head<R, T = unknown>(url: string, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typeGet, config });
+    return this.instance({ url, type: typeHead, config });
   }
   Patch<R, T = unknown>(url: string, data: RequestBody = {}, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typeGet, config, data });
+    return this.instance({ url, type: typePatch, config, data });
   }
   Options<R, T = unknown>(url: string, config?: AlovaMethodCreateConfig<R, T, RC, RH>) {
-    return this.instance({ url, type: typeGet, config });
+    return this.instance({ url, type: typeOptions, config });
   }
 }
 

--- a/typings/globalfetch.d.ts
+++ b/typings/globalfetch.d.ts
@@ -8,4 +8,4 @@ type FetchRequestInit = Omit<RequestInit, 'body' | 'headers' | 'method'>;
 type GlobalFetchRequestAdapter = AlovaRequestAdapter<any, any, FetchRequestInit, Response, Headers>;
 
 declare function GlobalFetch(): GlobalFetchRequestAdapter;
-export = GlobalFetch;
+export default GlobalFetch;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -517,6 +517,12 @@ export interface Alova<S, E, RC, RE, RH> {
   options: AlovaOptions<S, E, RC, RE, RH>;
   id: string;
   storage: AlovaGlobalStorage;
+  instance<R, T = unknown>(options: {
+    url: string;
+    type: MethodType;
+    data?: RequestBody;
+    config?: AlovaMethodCreateConfig<R, T, RC, RH>;
+  }): Method<S, E, R, T, RC, RE, RH>
   Get<R, T = unknown>(url: string, config?: AlovaMethodCreateConfig<R, T, RC, RH>): Method<S, E, R, T, RC, RE, RH>;
   Post<R, T = unknown>(
     url: string,


### PR DESCRIPTION
例

```js
const create = (data: Arg) => alova.Post('api/todo', data)
const update = (data: Arg) => alova.Put('api/todo', data)
const createOrUpdate = (data: Arg) => !!data?.id ? update(data) : create(data)
// 以下等于👆👆👆
const store = (data: Arg) => alova.instance({
  url: 'api/todo',
  type: ['POST', 'PUT'][Number(!!data?.id)],
  data
})
```