### PR TITLE
update: discussion form tamplate

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/feature-request.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-request.yml
@@ -1,0 +1,39 @@
+title: "\U0001F680 Feature Request:"
+labels: ['feature-request']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        :wave: Hi, thank you so much for supporting alova, it's really important for us!
+
+        **We aim to build alova into a common project for everyone, and encourage every developer to become a contributor to the alova community with an open and inclusive attitude. If you're interested, you can try to contribute by submitting a PR, it will let developers all over the world to use your code, please [see CONTRIBUTING](https://github.com/alovajs/alova/blob/main/CONTRIBUTING.md) for more details!**
+
+        :warning: Please read the following before submitting a new feature request/proposal:
+        - Confirm that it cannot be implemented through the existing APIs. Usually, we only add new features when the problem cannot be easily solved by the existing APIs, not just an alternative way of doing what can already be done
+        - Confirm that it is in line with alova's goal, please [see the goal of alova](https://github.com/alovajs/alova/blob/main/CONTRIBUTING.md#goal-of-alova)
+        - Make sure no duplicates are found in [Issues](https://github.com/alovajs/alova/issues) or [Discussion](https://github.com/alovajs/alova/discussions).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What problem does the new feature need to solve?
+      description: Before committing, please make sure to read [alova's development direction](../../CONTRIBUTING.md#goal-of-alova).
+    validations:
+      required: true
+
+  - type: textarea
+    id: expectation
+    attributes:
+      label: How should the new features you expect looks like?
+      description: You can provide a code design snippet of a new feature to express how the new feature you expect looks like in the new version.
+
+  - type: dropdown
+    id: importance
+    attributes:
+      label: How important is it to you?
+      options:
+        - Better to have
+        - Can make it easier to develop
+        - I'll give up alova without it
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,12 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-
-  - name: Feature Request
-    url: https://github.com/orgs/alovajs/discussions
+  - name: "\U0001F680 Feature Request"
+    url: https://github.com/orgs/alovajs/discussions/new?category=feature-request
     about: Suggest new features for consideration.
 
   - name: Questions & Discussions
-    url: https://github.com/alovajs/alova/discussions
+    url: https://github.com/orgs/alovajs/discussions/new?category=q-a
     about: Use GitHub discussions for your questions and discussions.
 
   - name: Official Documentation


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

<!-- 至少选择一个 / Choose at least one -->

- [ ] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [x] 其他，请描述 (Other, please describe): github template

**这个 PR 做了什么？/ What does this PR do?**

- 添加了 Feature Request 的 Discussion Form
- 修改了 Issue 配置，现在可以直接在 Issue 中点击并跳转到新建 Feature Request 页面。

**测试 / Testing**

已在其他 Repo 测试其功能，it works ✅

**屏幕截图 / Screenshots**

<img width="1190" alt="image" src="https://github.com/alovajs/alova/assets/40497962/f4ceabfc-bb5a-4dc5-bc3a-d7c1cc16a0d5">

<img width="934" alt="image" src="https://github.com/alovajs/alova/assets/40497962/0aae4140-aae4-4606-abd6-1c8b88a6a35f">

