### PR TITLE
fix: remove slash at the end when sending with empty url

### DIFF
--- a/src/functions/sendRequest.ts
+++ b/src/functions/sendRequest.ts
@@ -58,8 +58,13 @@ const adapterReturnMap: Record<string, Record<string, RequestAdapterReturnType>>
 const buildCompletedURL = (baseURL: string, url: string, params: Arg) => {
   // baseURL如果以/结尾，则去掉/
   baseURL = baseURL.endsWith('/') ? baseURL.slice(0, -1) : baseURL;
-  // 如果不是/或http协议开头的，则需要添加/
-  url = url.match(/^(\/|https?:\/\/)/) ? url : `/${url}`;
+
+  // Compatible with some RESTful usage
+  // fix: https://github.com/alovajs/alova/issues/382
+  if (url !== '') {
+    // 如果不是/或http协议开头的，则需要添加/
+    url = url.match(/^(\/|https?:\/\/)/) ? url : `/${url}`;
+  }
 
   const completeURL = baseURL + url;
 


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

#382 

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

Fix: url was added with a slash when it was empty

**文档 / Docs**

When the url is empty, a slash is no longer added before it

**测试 / Testing**

<img width="593" alt="image" src="https://github.com/alovajs/alova/assets/40497962/2fa70587-3853-4ef0-9686-3d397a2b518a">

All tests passed.