### PR TITLE
fix: return response data in `middleware.next` of `useSQRequest`

### DIFF
--- a/.changeset/shiny-pigs-pretend.md
+++ b/.changeset/shiny-pigs-pretend.md
@@ -1,0 +1,6 @@
+---
+'@alova/shared': patch
+'alova': patch
+---
+
+return response data in `middleware.next` of `useSQRequest`

--- a/.changeset/thin-zebras-return.md
+++ b/.changeset/thin-zebras-return.md
@@ -1,0 +1,5 @@
+---
+'@alova/mock': patch
+---
+
+fix that throw error when return null in mock api

--- a/internal/jest.setup.mock.ts
+++ b/internal/jest.setup.mock.ts
@@ -15,9 +15,9 @@ Object.defineProperties(globalThis, {
   }
 });
 
-// if the environment is jsdom, set process.browser to true
+// if the environment is jsdom, set process.cwd to undefined
 if (typeof window !== 'undefined') {
-  (process as any).browser = true;
+  (process as any).cwd = undefined;
 }
 
 // undici must import after defining TextDecoder and TextEncoder, otherwise it will throw error

--- a/packages/adapter-mock/typings/index.d.ts
+++ b/packages/adapter-mock/typings/index.d.ts
@@ -84,7 +84,7 @@ export interface StatusResponse {
   body?: any;
 }
 export type MockFunction = (request: MockServerRequest) => StatusResponse | any;
-export type Mock = Record<string, MockFunction | string | number | Record<string, any> | any[]>;
+export type Mock = Record<string, MockFunction | string | number | null | Record<string, any> | any[]>;
 
 export interface MockWrapper {
   enable: boolean;

--- a/packages/alova/typings/index.d.ts
+++ b/packages/alova/typings/index.d.ts
@@ -227,6 +227,10 @@ export interface ReferingObject {
    * the map of tracked state keys
    */
   trackedKeys: Record<string, boolean>;
+  /**
+   * has been bound error event
+   */
+  bindError: boolean;
   [key: string]: any;
 }
 export interface StatesHook<State, Computed, Watched = State | Computed, Export = State> {

--- a/packages/client/src/hooks/silent/globalVariables.ts
+++ b/packages/client/src/hooks/silent/globalVariables.ts
@@ -125,4 +125,4 @@ export type GlobalSQEvents = {
 export const globalSQEventManager = createEventManager<GlobalSQEvents>();
 
 /** silentAssert */
-export const silentAssert = createAssert('useSQHook');
+export const silentAssert = createAssert('useSQRequest');

--- a/packages/client/src/hooks/silent/useSQRequest.ts
+++ b/packages/client/src/hooks/silent/useSQRequest.ts
@@ -1,6 +1,5 @@
 import useRequest from '@/hooks/core/useRequest';
 import { noop, statesHookHelper } from '@alova/shared/function';
-import { promiseResolve, undefinedValue } from '@alova/shared/vars';
 import { AlovaGenerics, promiseStatesHook } from 'alova';
 import { AlovaMethodHandler, SQRequestHookConfig, UseHookExposure } from '~/typings/clienthook';
 import createSilentQueueMiddlewares from './createSilentQueueMiddlewares';
@@ -21,8 +20,9 @@ export default function useSQRequest<AG extends AlovaGenerics>(
     ...config,
     __referingObj: referingObj,
     middleware: (ctx, next) => {
-      middleware(ctx, () => promiseResolve(undefinedValue as any));
-      return silentMiddleware(ctx, next);
+      const silentMidPromise = silentMiddleware(ctx, next);
+      middleware(ctx, () => silentMidPromise);
+      return silentMidPromise;
     }
   });
   decorateEvent(states as UseHookExposure<AG>);

--- a/packages/client/test/vue/useSQRequest.spec.ts
+++ b/packages/client/test/vue/useSQRequest.spec.ts
@@ -533,13 +533,13 @@ describe('vue => useSQRequest', () => {
         id: '--'
       })
     });
-    onPostSuccess(event => {
+    onPostSuccess(async event => {
       const { data } = event;
       expect(postRes.value[symbolVDataId]).toBeTruthy(); // 此时还是虚拟响应数据
 
       // 调用updateStateEffect后将首先立即更新虚拟数据到listData中
       // 等到请求响应后再次更新实际数据到listData中
-      const updated = updateStateEffect(getter(), listDataRaw => {
+      const updated = await updateStateEffect(getter(), listDataRaw => {
         listDataRaw.push({
           id: data.id,
           text: 'abc'

--- a/packages/shared/src/function.ts
+++ b/packages/shared/src/function.ts
@@ -385,7 +385,7 @@ type CompletedExposingProvider<AG extends AlovaGenerics, O extends Record<string
  */
 export function statesHookHelper<AG extends AlovaGenerics>(
   statesHook: StatesHook<GeneralState, GeneralState>,
-  referingObject: ReferingObject = { trackedKeys: {} }
+  referingObject: ReferingObject = { trackedKeys: {}, bindError: falseValue }
 ) {
   const ref = <Data>(initialValue: Data) => (statesHook.ref ? statesHook.ref(initialValue) : { current: initialValue });
   referingObject = ref(referingObject).current;
@@ -491,8 +491,10 @@ export function statesHookHelper<AG extends AlovaGenerics>(
       }
 
       const { update: nestedHookUpdate, __proxyState: nestedProxyState } = provider;
-      // reset the tracked keys, so that the nest hook providers can be initialized.
+      // reset the tracked keys and bingError flag, so that the nest hook providers can be initialized.
       referingObject.trackedKeys = {};
+      referingObject.bindError = falseValue;
+
       const extraProvider = {
         // expose referingObject automatically.
         __referingObj: referingObject,


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

[Issue ID]
<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

fix some beta bugs.

close #422, #424, #426, #427

[简要描述所做更改 / Describe the changes briefly]

**文档 / Docs**

[此次 PR 的文档 / Docs for this PR]

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

tests have been added.

[描述测试结果 / Describe the test results.]

passed