### PR TITLE
fix: cannot force send in restore mode in hooks

### DIFF
--- a/src/functions/sendRequest.ts
+++ b/src/functions/sendRequest.ts
@@ -118,7 +118,7 @@ export default function sendRequest<S, E, R, T, RC, RE, RH>(
         : getResponseCache(id, methodKey);
 
       // 如果是STORAGE_RESTORE模式，且缓存没有数据时，则需要将持久化数据恢复到缓存中，过期时间要使用缓存的
-      if (cacheMode === STORAGE_RESTORE && !cachedResponse) {
+      if (!forceRequest && cacheMode === STORAGE_RESTORE && !cachedResponse) {
         const rawPersistentData = getPersistentRawData(id, methodKey, storage, tag);
         if (rawPersistentData) {
           const [persistentResponse, persistentExpireMilliseconds] = rawPersistentData;


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

close #449 
<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

fix: cannot force send in restore mode in hooks

**文档 / Docs**

相关代码：[src/functions/sendRequest.ts#L121](https://github.com/alovajs/alova/blob/cdd0fb4ef9ff71e8d5ee5f65f0e4c065e4ec11c4/src/functions/sendRequest.ts#L121)

强制请求时，cache 不会被读取，因此为 `undefined`

如上述代码所示，在 restore 模式下只要 cache 为空，就尝试从持久化数据中恢复 cache。
这导致命中 cache ，认为本次请求无需发出。

PR 添加了判断条件，在 `force == true` 时始终不从持久化中恢复；并添加了一个针对 restore 和 force 请求的测试。

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

ALL tests passed.

<img width="470" alt="image" src="https://github.com/alovajs/alova/assets/40497962/e2e80667-d3bc-4363-a975-85386c00132c">

