### PR TITLE
fix: cannot stop pushing SilentMethod into queue when using async handler in onBeforePushQueue(#434)

### DIFF
--- a/.changeset/angry-laws-dream.md
+++ b/.changeset/angry-laws-dream.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+fix: cannot stop pushing SilentMethod into queue when using async handler in onBeforePushQueue(#434)

--- a/packages/alova/typings/clienthook/hooks/useFetcher.d.ts
+++ b/packages/alova/typings/clienthook/hooks/useFetcher.d.ts
@@ -1,4 +1,13 @@
-import { Alova, AlovaGenerics, FetchRequestState, Method, Progress, ReferingObject, StatesHook } from 'alova';
+import {
+  Alova,
+  AlovaGenerics,
+  FetchRequestState,
+  Method,
+  Progress,
+  ReferingObject,
+  StatesExport,
+  StatesHook
+} from 'alova';
 import {
   AlovaFetcherMiddleware,
   ExportedState,
@@ -24,14 +33,14 @@ export interface FetcherHookConfig<AG extends AlovaGenerics = AlovaGenerics> ext
   updateState?: boolean;
 }
 
-export interface UseFetchExportedState<State>
+export interface UseFetchExportedState<SE extends StatesExport>
   extends FetchRequestState<
-    ExportedState<boolean, State>,
-    ExportedState<Error | undefined, State>,
-    ExportedState<Progress, State>,
-    ExportedState<Progress, State>
+    ExportedState<boolean, SE>,
+    ExportedState<Error | undefined, SE>,
+    ExportedState<Progress, SE>,
+    ExportedState<Progress, SE>
   > {}
-export interface UseFetchHookExposure<SE extends StatesExport> extends UseFetchExportedState<SE['State']> {
+export interface UseFetchHookExposure<SE extends StatesExport> extends UseFetchExportedState<SE> {
   fetch<R>(matcher: Method<AlovaGenerics<R>>, ...args: any[]): Promise<R>;
   update: StateUpdater<UseFetchExportedState<SE['State']>, SE>;
   abort: UseHookExposure['abort'];

--- a/packages/alova/typings/clienthook/hooks/useSQRequest.d.ts
+++ b/packages/alova/typings/clienthook/hooks/useSQRequest.d.ts
@@ -351,7 +351,9 @@ export interface SQHookConfig<AG extends AlovaGenerics> {
 export type SQRequestHookConfig<AG extends AlovaGenerics> = SQHookConfig<AG> & RequestHookConfig<AG>;
 export type FallbackHandler<AG extends AlovaGenerics> = (event: ScopedSQEvent<AG>) => void;
 export type RetryHandler<AG extends AlovaGenerics> = (event: ScopedSQRetryEvent<AG>) => void;
-export type BeforePushQueueHandler<AG extends AlovaGenerics> = (event: ScopedSQEvent<AG>) => void | boolean;
+export type BeforePushQueueHandler<AG extends AlovaGenerics> = (
+  event: ScopedSQEvent<AG>
+) => void | boolean | Promise<void | boolean>;
 export type PushedQueueHandler<AG extends AlovaGenerics> = (event: ScopedSQEvent<AG>) => void;
 export type SQHookExposure<AG extends AlovaGenerics> = Omit<
   UseHookExposure<AG>,

--- a/packages/client/src/hooks/silent/silentQueue.ts
+++ b/packages/client/src/hooks/silent/silentQueue.ts
@@ -364,13 +364,14 @@ export const pushNewSilentMethod2Queue = async <AG extends AlovaGenerics>(
   silentMethodInstance: SilentMethod<AG>,
   cache: boolean,
   targetQueueName = DEFAULT_QUEUE_NAME,
-  onBeforePush: () => any[] = () => []
+  onBeforePush: () => any[] | Promise<any>[] = () => []
 ) => {
   silentMethodInstance.cache = cache;
   const currentQueue = (silentQueueMap[targetQueueName] =
     silentQueueMap[targetQueueName] || []) as unknown as SilentMethod<AG>[];
   const isNewQueue = len(currentQueue) <= 0;
-  const isPush2Queue = !onBeforePush().some(returns => returns === falseValue);
+  const beforePushReturns = await Promise.all(onBeforePush());
+  const isPush2Queue = !beforePushReturns.some(returns => returns === falseValue);
 
   // silent行为下，如果没有绑定fallback事件回调，则持久化
   // 如果在onBeforePushQueue返回false，也不再放入队列中

--- a/packages/client/test/vue/useSQRequest.spec.ts
+++ b/packages/client/test/vue/useSQRequest.spec.ts
@@ -263,15 +263,19 @@ describe('vue => useSQRequest', () => {
 
   test('should prevent to push silentMethod when return false in certain callback of onBeforePushQueue', async () => {
     const queue = 'tb4';
+    const successMockFn = jest.fn();
     const Get = () => alovaInst.Get<any>('/list');
-    const { onBeforePushQueue, onSuccess } = useSQRequest(Get, {
+    const { onBeforePushQueue } = useSQRequest(Get, {
       behavior: 'queue',
       queue
-    });
+    }).onSuccess(successMockFn);
+    const { onBeforePushQueue: onBeforePushQueueAsync } = useSQRequest(Get, {
+      behavior: 'queue',
+      queue
+    }).onSuccess(successMockFn);
     onBeforePushQueue(() => false);
+    onBeforePushQueueAsync(() => Promise.resolve(false));
 
-    const successMockFn = jest.fn();
-    onSuccess(successMockFn);
     await delay(0);
     expect(silentQueueMap[queue]).toStrictEqual([]);
     await delay(500);

--- a/packages/client/typings/clienthook/hooks/useSQRequest.d.ts
+++ b/packages/client/typings/clienthook/hooks/useSQRequest.d.ts
@@ -351,7 +351,9 @@ export interface SQHookConfig<AG extends AlovaGenerics> {
 export type SQRequestHookConfig<AG extends AlovaGenerics> = SQHookConfig<AG> & RequestHookConfig<AG>;
 export type FallbackHandler<AG extends AlovaGenerics> = (event: ScopedSQEvent<AG>) => void;
 export type RetryHandler<AG extends AlovaGenerics> = (event: ScopedSQRetryEvent<AG>) => void;
-export type BeforePushQueueHandler<AG extends AlovaGenerics> = (event: ScopedSQEvent<AG>) => void | boolean;
+export type BeforePushQueueHandler<AG extends AlovaGenerics> = (
+  event: ScopedSQEvent<AG>
+) => void | boolean | Promise<void | boolean>;
 export type PushedQueueHandler<AG extends AlovaGenerics> = (event: ScopedSQEvent<AG>) => void;
 export type SQHookExposure<AG extends AlovaGenerics> = Omit<
   UseHookExposure<AG>,


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

#434)
<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

fix: cannot stop pushing SilentMethod into queue when using async handler in onBeforePushQueue(#434)

**文档 / Docs**

None

**测试 / Testing**

ALL tests passed.
