### PR TITLE
refactor: change the name `sendArgs` to `args`

### DIFF
--- a/.changeset/tiny-pants-cross.md
+++ b/.changeset/tiny-pants-cross.md
@@ -1,0 +1,7 @@
+---
+'@alova/vue-options': minor
+'@alova/shared': minor
+'alova': minor
+---
+
+change the name `sendArgs` to `args`

--- a/examples/react/src/views/LoadMoreList/index.jsx
+++ b/examples/react/src/views/LoadMoreList/index.jsx
@@ -38,7 +38,7 @@ function View() {
 
   const { send: removeSend, loading: removing } = useRequest(({ id }) => removeStudent(id), {
     immediate: false
-  }).onSuccess(({ sendArgs: [row] }) => {
+  }).onSuccess(({ args: [row] }) => {
     remove(row);
   });
 

--- a/examples/react/src/views/Notes/Editor.jsx
+++ b/examples/react/src/views/Notes/Editor.jsx
@@ -49,7 +49,7 @@ function Editor({ networkMode, queue, id }) {
         return false;
       }
     })
-    .onSuccess(async ({ silentMethod, sendArgs: [content] }) => {
+    .onSuccess(async ({ silentMethod, args: [content] }) => {
       let editingItem = undefined;
       // 步骤1：手动更新列表数据
       await setCache(methodNoteList, noteList => {

--- a/examples/react/src/views/Notes/index.jsx
+++ b/examples/react/src/views/Notes/index.jsx
@@ -20,7 +20,7 @@ function View() {
     behavior: () => (networkMode === 0 ? 'queue' : 'static'),
     queue,
     initialData: [],
-    force: ({ sendArgs: [isForce] }) => !!isForce
+    force: ({ args: [isForce] }) => !!isForce
   }).onSuccess(({ data: noteListRaw }) => {
     // 步骤3：将未提交的数据手动补充到列表，以便即使数据未提交也能展示最新状态
     filterSilentMethods(undefined, queue).then(noteSilentMethods => {
@@ -58,7 +58,7 @@ function View() {
       endQuiver: 0.5
     },
     immediate: false
-  }).onSuccess(({ silentMethod, sendArgs: [removedId] }) => {
+  }).onSuccess(({ silentMethod, args: [removedId] }) => {
     // setp1: update list data manually
     updateStateEffect(queryNotes(), noteList => {
       const index = noteList.findIndex(({ id }) => id === removedId);

--- a/examples/react/src/views/PaginatedList/index.jsx
+++ b/examples/react/src/views/PaginatedList/index.jsx
@@ -38,7 +38,7 @@ function View() {
 
   const { send: removeSend, loading: removing } = useRequest(({ id }) => removeStudent(id), {
     immediate: false
-  }).onSuccess(({ sendArgs: [row] }) => {
+  }).onSuccess(({ args: [row] }) => {
     remove(row);
   });
 

--- a/examples/react/src/views/Settings.jsx
+++ b/examples/react/src/views/Settings.jsx
@@ -46,7 +46,7 @@ function View() {
       endQuiver: 0.5
     },
     immediate: false
-  }).onSuccess(({ silentMethod, sendArgs: [name, value] }) => {
+  }).onSuccess(({ silentMethod, args: [name, value] }) => {
     settingData[name] = value;
     if (silentMethod) {
       silentMethod.reviewData = { name, value };

--- a/examples/react/src/views/SimpleList/index.jsx
+++ b/examples/react/src/views/SimpleList/index.jsx
@@ -89,7 +89,7 @@ function View() {
       endQuiver: 0.5
     },
     immediate: false
-  }).onSuccess(({ sendArgs: [removeId], silentMethod }) => {
+  }).onSuccess(({ args: [removeId], silentMethod }) => {
     update({
       data: todos.filter(todo => todo.id !== removeId)
     });

--- a/examples/svelte/src/views/LoadMoreList/index.svelte
+++ b/examples/svelte/src/views/LoadMoreList/index.svelte
@@ -37,7 +37,7 @@
 
   const { send: removeSend, loading: removing } = useRequest(({ id }) => removeStudent(id), {
     immediate: false
-  }).onSuccess(({ sendArgs: [row] }) => {
+  }).onSuccess(({ args: [row] }) => {
     remove(row);
   });
 

--- a/examples/svelte/src/views/Notes/Editor.svelte
+++ b/examples/svelte/src/views/Notes/Editor.svelte
@@ -53,7 +53,7 @@
         return false;
       }
     })
-    .onSuccess(async ({ silentMethod, sendArgs: [content] }) => {
+    .onSuccess(async ({ silentMethod, args: [content] }) => {
       let editingItem = undefined;
       await setCache(methodNoteList, noteList => {
         if (!noteList || !currentId) {

--- a/examples/svelte/src/views/Notes/index.svelte
+++ b/examples/svelte/src/views/Notes/index.svelte
@@ -18,7 +18,7 @@
     behavior: () => (networkMode === 0 ? 'queue' : 'static'),
     queue,
     initialData: [],
-    force: ({ sendArgs: [isForce] }) => !!isForce
+    force: ({ args: [isForce] }) => !!isForce
   }).onSuccess(({ data: noteListRaw }) => {
     filterSilentMethods(undefined, queue).then(noteSilentMethods => {
       console.log(noteSilentMethods);
@@ -53,7 +53,7 @@
       endQuiver: 0.5
     },
     immediate: false
-  }).onSuccess(({ silentMethod, sendArgs: [removedId] }) => {
+  }).onSuccess(({ silentMethod, args: [removedId] }) => {
     updateStateEffect(queryNotes(), noteList => {
       const index = noteList.findIndex(({ id }) => id === removedId);
       if (index >= 0) {

--- a/examples/svelte/src/views/PaginatedList/index.svelte
+++ b/examples/svelte/src/views/PaginatedList/index.svelte
@@ -31,7 +31,7 @@
 
   const { send: removeSend, loading: removing } = useRequest(({ id }) => removeStudent(id), {
     immediate: false
-  }).onSuccess(({ sendArgs: [row] }) => {
+  }).onSuccess(({ args: [row] }) => {
     remove(row);
   });
 

--- a/examples/svelte/src/views/Settings.svelte
+++ b/examples/svelte/src/views/Settings.svelte
@@ -36,7 +36,7 @@
       endQuiver: 0.5
     },
     immediate: false
-  }).onSuccess(({ silentMethod, sendArgs: [name, value] }) => {
+  }).onSuccess(({ silentMethod, args: [name, value] }) => {
     $settingData[name] = value;
     if (silentMethod) {
       silentMethod.reviewData = { name, value };

--- a/examples/svelte/src/views/SimpleList/index.svelte
+++ b/examples/svelte/src/views/SimpleList/index.svelte
@@ -41,7 +41,7 @@
       endQuiver: 0.5
     },
     immediate: false
-  }).onSuccess(({ sendArgs: [removeId], silentMethod }) => {
+  }).onSuccess(({ args: [removeId], silentMethod }) => {
     $todos = $todos.filter(todo => todo.id !== removeId);
     if (silentMethod) {
       silentMethod.reviewData = {

--- a/examples/vue/src/views/LoadMoreList/index.vue
+++ b/examples/vue/src/views/LoadMoreList/index.vue
@@ -85,7 +85,7 @@ const editItem = id => {
 
 const { send: removeSend, loading: removing } = useRequest(({ id }) => removeStudent(id), {
   immediate: false
-}).onSuccess(({ sendArgs: [row] }) => {
+}).onSuccess(({ args: [row] }) => {
   remove(row);
 });
 

--- a/examples/vue/src/views/Notes/Editor.vue
+++ b/examples/vue/src/views/Notes/Editor.vue
@@ -72,7 +72,7 @@ const { loading: editing, send: submitNote } = useSQRequest(content => editNote(
       return false;
     }
   })
-  .onSuccess(async ({ silentMethod, sendArgs: [content] }) => {
+  .onSuccess(async ({ silentMethod, args: [content] }) => {
     let editingItem = undefined;
     await setCache(methodNoteList, noteList => {
       if (!noteList || !currentId.value) {

--- a/examples/vue/src/views/Notes/index.vue
+++ b/examples/vue/src/views/Notes/index.vue
@@ -76,7 +76,7 @@ const {
   behavior: () => (networkMode.value === 0 ? 'queue' : 'static'),
   queue,
   initialData: [],
-  force: ({ sendArgs: [isForce] }) => !!isForce
+  force: ({ args: [isForce] }) => !!isForce
 }).onSuccess(({ data: noteListRaw }) => {
   filterSilentMethods(undefined, queue).then(noteSilentMethods => {
     console.log(noteSilentMethods);
@@ -111,7 +111,7 @@ const { loading: removing, send: removeSend } = useSQRequest(id => removeNote(id
     endQuiver: 0.5
   },
   immediate: false
-}).onSuccess(({ silentMethod, sendArgs: [removedId] }) => {
+}).onSuccess(({ silentMethod, args: [removedId] }) => {
   // setp1: update list data manually
   updateStateEffect(queryNotes(), noteList => {
     const index = noteList.findIndex(({ id }) => id === removedId);

--- a/examples/vue/src/views/PaginatedList/index.vue
+++ b/examples/vue/src/views/PaginatedList/index.vue
@@ -88,7 +88,7 @@ const {
 
 const { send: removeSend, loading: removing } = useRequest(({ id }) => removeStudent(id), {
   immediate: false
-}).onSuccess(({ sendArgs: [row] }) => {
+}).onSuccess(({ args: [row] }) => {
   remove(row);
 });
 

--- a/examples/vue/src/views/Settings.vue
+++ b/examples/vue/src/views/Settings.vue
@@ -86,7 +86,7 @@ const { send: submitData, loading: submittingLoading } = useSQRequest((name, val
     endQuiver: 0.5
   },
   immediate: false
-}).onSuccess(({ silentMethod, sendArgs: [name, value] }) => {
+}).onSuccess(({ silentMethod, args: [name, value] }) => {
   settingData[name] = value;
   if (silentMethod) {
     silentMethod.reviewData = { name, value };

--- a/examples/vue/src/views/SimpleList/index.vue
+++ b/examples/vue/src/views/SimpleList/index.vue
@@ -75,7 +75,7 @@ const { send: removeSend, loading: removing } = useSQRequest(id => removeTodo(id
     endQuiver: 0.5
   },
   immediate: false
-}).onSuccess(({ sendArgs: [removeId], silentMethod }) => {
+}).onSuccess(({ args: [removeId], silentMethod }) => {
   todos.value = todos.value.filter(todo => todo.id !== removeId);
   if (silentMethod) {
     silentMethod.reviewData = {

--- a/packages/alova/typings/clienthook/general.d.ts
+++ b/packages/alova/typings/clienthook/general.d.ts
@@ -26,7 +26,7 @@ export interface AlovaEvent<AG extends AlovaGenerics> {
   /**
    * params from send function
    */
-  sendArgs: any[];
+  args: any[];
   /**
    * current method instance
    */

--- a/packages/alova/typings/clienthook/hooks/useSQRequest.d.ts
+++ b/packages/alova/typings/clienthook/hooks/useSQRequest.d.ts
@@ -82,7 +82,7 @@ export interface ScopedSQEvent<AG extends AlovaGenerics> extends SQEvent<AG> {
   /**
    * 通过send触发请求时传入的参数
    */
-  sendArgs: any[];
+  args: any[];
 }
 /** 局部成功事件 */
 export interface ScopedSQSuccessEvent<AG extends AlovaGenerics> extends ScopedSQEvent<AG> {

--- a/packages/alova/typings/clienthook/hooks/useSSE.d.ts
+++ b/packages/alova/typings/clienthook/hooks/useSSE.d.ts
@@ -68,9 +68,9 @@ export interface SSEExposure<AG extends AlovaGenerics, Data> {
   eventSource: ExportedState<EventSource | undefined, AG['StatesExport']>;
   /**
    * 手动发起请求。在使用 `immediate: true` 时该方法会自动触发
-   * @param sendArgs 请求参数，会传递给 method
+   * @param args 请求参数，会传递给 method
    */
-  send(...sendArgs: any[]): Promise<void>;
+  send(...args: any[]): Promise<void>;
   /**
    * 关闭连接
    */

--- a/packages/alova/typings/serverhook.d.ts
+++ b/packages/alova/typings/serverhook.d.ts
@@ -5,10 +5,10 @@
   * Licensed under MIT (https://github.com/alovajs/alova/blob/main/LICENSE)
 */
 
-import { BackoffPolicy } from '@alova/shared/types';
-import { IRateLimiterStoreOptions, RateLimiterRes } from 'rate-limiter-flexible';
+import { AlovaGenerics, Method, AlovaGlobalCacheAdapter } from 'alova';
+import { RateLimiterRes, IRateLimiterStoreOptions } from 'rate-limiter-flexible';
 import RateLimiterStoreAbstract from 'rate-limiter-flexible/lib/RateLimiterStoreAbstract.js';
-import { AlovaGenerics, AlovaGlobalCacheAdapter, Method } from '.';
+import { BackoffPolicy } from '@alova/shared/types';
 
 type RequestHandler<Responded> = (forceRequest?: boolean) => Promise<Responded>;
 declare class HookedMethod<AG extends AlovaGenerics> extends Method<AG> {
@@ -133,5 +133,4 @@ interface RetryOptions {
 }
 declare const retry: <AG extends AlovaGenerics>(method: Method<AG>, options?: RetryOptions) => HookedMethod<AG>;
 
-export { createRateLimiter, HookedMethod, retry };
-
+export { HookedMethod, createRateLimiter, retry };

--- a/packages/client/src/event.ts
+++ b/packages/client/src/event.ts
@@ -21,7 +21,7 @@ export class AlovaSSEEvent<AG extends AlovaGenerics> extends AlovaEventBase<AG> 
   eventSource: EventSource; // eventSource实例
 
   constructor(base: AlovaEventBase<AG>, eventSource: EventSource) {
-    super(base.method, base.sendArgs);
+    super(base.method, base.args);
     this.eventSource = eventSource;
   }
 }
@@ -174,11 +174,11 @@ export class ScopedSQEvent<AG extends AlovaGenerics> extends SQEvent<AG> impleme
   /**
    * 通过send触发请求时传入的参数
    */
-  sendArgs: any[];
+  args: any[];
 
-  constructor(behavior: SQHookBehavior, method: Method<AG>, silentMethod: SilentMethod<AG>, sendArgs: any[]) {
+  constructor(behavior: SQHookBehavior, method: Method<AG>, silentMethod: SilentMethod<AG>, args: any[]) {
     super(behavior, method, silentMethod);
-    this.sendArgs = sendArgs;
+    this.args = args;
   }
 }
 
@@ -195,10 +195,10 @@ export class ScopedSQSuccessEvent<AG extends AlovaGenerics>
     behavior: SQHookBehavior,
     method: Method<AG>,
     silentMethod: SilentMethod<AG>,
-    sendArgs: any[],
+    args: any[],
     data: AG['Responded']
   ) {
-    super(behavior, method, silentMethod, sendArgs);
+    super(behavior, method, silentMethod, args);
     this.data = data;
   }
 }
@@ -209,14 +209,8 @@ export class ScopedSQErrorEvent<AG extends AlovaGenerics> extends ScopedSQEvent<
    */
   error: any;
 
-  constructor(
-    behavior: SQHookBehavior,
-    method: Method<AG>,
-    silentMethod: SilentMethod<AG>,
-    sendArgs: any[],
-    error: any
-  ) {
-    super(behavior, method, silentMethod, sendArgs);
+  constructor(behavior: SQHookBehavior, method: Method<AG>, silentMethod: SilentMethod<AG>, args: any[], error: any) {
+    super(behavior, method, silentMethod, args);
     this.error = error;
   }
 }
@@ -236,11 +230,11 @@ export class ScopedSQRetryEvent<AG extends AlovaGenerics> extends ScopedSQEvent<
     behavior: SQHookBehavior,
     method: Method<AG>,
     silentMethod: SilentMethod<AG>,
-    sendArgs: any[],
+    args: any[],
     retryTimes: number,
     retryDelay: number
   ) {
-    super(behavior, method, silentMethod, sendArgs);
+    super(behavior, method, silentMethod, args);
     this.retryTimes = retryTimes;
     this.retryDelay = retryDelay;
   }
@@ -269,12 +263,12 @@ export class ScopedSQCompleteEvent<AG extends AlovaGenerics>
     behavior: SQHookBehavior,
     method: Method<AG>,
     silentMethod: SilentMethod<AG>,
-    sendArgs: any[],
+    args: any[],
     status: AlovaCompleteEvent<AG>['status'],
     data?: AG['Responded'],
     error?: any
   ) {
-    super(behavior, method, silentMethod, sendArgs);
+    super(behavior, method, silentMethod, args);
     this.status = status;
     this.data = data;
     this.error = error;
@@ -296,7 +290,7 @@ export class RetriableRetryEvent<AG extends AlovaGenerics>
   retryDelay: number;
 
   constructor(base: AlovaEventBase<AG>, retryTimes: number, retryDelay: number) {
-    super(base.method, base.sendArgs);
+    super(base.method, base.args);
     this.retryTimes = retryTimes;
     this.retryDelay = retryDelay;
   }

--- a/packages/client/src/hooks/pagination/usePagination.ts
+++ b/packages/client/src/hooks/pagination/usePagination.ts
@@ -87,7 +87,7 @@ export default <AG extends AlovaGenerics, ListData extends unknown[]>(
   // 初始化fetcher
   const fetchStates = useFetcher<FetcherType<Alova<AG>>>({
     __referingObj: referingObject,
-    force: ({ sendArgs }) => sendArgs[0]
+    force: ({ args }) => args[0]
   });
   const { loading, fetch, abort: abortFetch, onSuccess: onFetchSuccess } = fetchStates;
   const fetchingRef = ref(loading);
@@ -156,7 +156,7 @@ export default <AG extends AlovaGenerics, ListData extends unknown[]>(
 
       return next();
     },
-    force: event => event.sendArgs[1] || (isFn(force) ? force(event) : force),
+    force: event => event.args[1] || (isFn(force) ? force(event) : force),
     ...others
   });
   const { send } = states;
@@ -289,7 +289,7 @@ export default <AG extends AlovaGenerics, ListData extends unknown[]>(
       }
     }
   });
-  states.onSuccess(({ data: rawData, sendArgs: [refreshPage, isRefresh], method }) => {
+  states.onSuccess(({ data: rawData, args: [refreshPage, isRefresh], method }) => {
     const { total: cachedTotal } = getSnapshotMethods(method) || {};
     const typedRawData = rawData as any[];
     total.v = cachedTotal !== undefinedValue ? cachedTotal : totalGetter(typedRawData);

--- a/packages/client/src/hooks/silent/createSilentQueueMiddlewares.ts
+++ b/packages/client/src/hooks/silent/createSilentQueueMiddlewares.ts
@@ -84,7 +84,7 @@ export default <AG extends AlovaGenerics>(handler: Method<AG> | AlovaMethodHandl
           behaviorFinally,
           event.method,
           silentMethodInstance,
-          event.sendArgs,
+          event.args,
           event.data
         ) as any
       );
@@ -97,7 +97,7 @@ export default <AG extends AlovaGenerics>(handler: Method<AG> | AlovaMethodHandl
           behaviorFinally,
           event.method,
           silentMethodInstance,
-          event.sendArgs,
+          event.args,
           event.error
         )
       );
@@ -109,7 +109,7 @@ export default <AG extends AlovaGenerics>(handler: Method<AG> | AlovaMethodHandl
           behaviorFinally,
           event.method,
           silentMethodInstance,
-          event.sendArgs,
+          event.args,
           event.status,
           event.data,
           event.error

--- a/packages/client/src/hooks/useRetriableRequest.ts
+++ b/packages/client/src/hooks/useRetriableRequest.ts
@@ -41,14 +41,14 @@ export default <AG extends AlovaGenerics>(
   const retryTimes = useFlag$(0);
   const stopManuallyError = useFlag$(undefinedValue as Error | undefined); // 停止错误对象，在手动触发停止时有值
   const methodInstanceLastest = useFlag$(undefinedValue as Method<AG> | undefined);
-  const sendArgsLatest = useFlag$(undefinedValue as any[] | undefined);
+  const argsLatest = useFlag$(undefinedValue as any[] | undefined);
   const currentLoadingState = useFlag$(falseValue);
   const requesting = useFlag$(falseValue); // 是否正在请求
   const retryTimer = useFlag$(undefinedValue as string | number | NodeJS.Timeout | undefined);
   const promiseObj = useFlag$(usePromise());
   const requestResolved = useFlag$(falseValue);
 
-  const emitOnFail = (method: Method<AG>, sendArgs: any[], error: any) => {
+  const emitOnFail = (method: Method<AG>, args: any[], error: any) => {
     if (requestResolved.current) {
       return;
     }
@@ -57,7 +57,7 @@ export default <AG extends AlovaGenerics>(
     setTimeoutFn(() => {
       eventManager.emit(
         FailEventKey,
-        newInstance(RetriableFailEvent<AG>, AlovaEventBase.spawn(method, sendArgs), error, retryTimes.current)
+        newInstance(RetriableFailEvent<AG>, AlovaEventBase.spawn(method, args), error, retryTimes.current)
       );
       stopManuallyError.current = undefinedValue;
       retryTimes.current = 0; // 重置已重试次数
@@ -88,7 +88,7 @@ export default <AG extends AlovaGenerics>(
       controlLoading();
       setLoading(trueValue);
       methodInstanceLastest.current = method;
-      sendArgsLatest.current = args;
+      argsLatest.current = args;
       requesting.current = trueValue;
 
       // init the resolved flag as `false` before first request.
@@ -164,7 +164,7 @@ export default <AG extends AlovaGenerics>(
 
       // raise fail event at the end, because the above process depends on `stopManuallyError`
       // emit this event will clears this variable
-      emitOnFail(methodInstanceLastest.current as any, sendArgsLatest.current as any, stopManuallyError.current);
+      emitOnFail(methodInstanceLastest.current as any, argsLatest.current as any, stopManuallyError.current);
     }
   };
 

--- a/packages/client/src/hooks/useSSE.ts
+++ b/packages/client/src/hooks/useSSE.ts
@@ -68,7 +68,7 @@ export default <Data = any, AG extends AlovaGenerics = AlovaGenerics>(
 
   const { create, ref, onMounted, onUnmounted, objectify, exposeProvider } = statesHookHelper<AG>(promiseStatesHook());
 
-  const usingSendArgs = ref<any[]>([]);
+  const usingargs = ref<any[]>([]);
   const eventSource = ref<EventSource | undefined>(undefinedValue);
   const sendPromiseObject = ref<UsePromiseExposure<void> | undefined>(undefinedValue);
 
@@ -142,7 +142,7 @@ export default <Data = any, AG extends AlovaGenerics = AlovaGenerics>(
     assert(!!eventSource.current, 'EventSource is not initialized');
     const es = eventSource.current!;
 
-    const baseEvent = new AlovaSSEEvent(AlovaEventBase.spawn(methodInstance, usingSendArgs.current), es);
+    const baseEvent = new AlovaSSEEvent(AlovaEventBase.spawn(methodInstance, usingargs.current), es);
 
     if (eventFrom === MessageType.Open) {
       return Promise.resolve(baseEvent);
@@ -274,7 +274,7 @@ export default <Data = any, AG extends AlovaGenerics = AlovaGenerics>(
   /**
    * 发送请求并初始化 eventSource
    */
-  const connect = (...sendArgs: any[]) => {
+  const connect = (...args: any[]) => {
     let es = eventSource.current;
     let promiseObj = sendPromiseObject.current;
     if (es && abortLast) {
@@ -292,8 +292,8 @@ export default <Data = any, AG extends AlovaGenerics = AlovaGenerics>(
         });
     }
 
-    usingSendArgs.current = sendArgs;
-    methodInstance = getHandlerMethod(handler, sendArgs);
+    usingargs.current = args;
+    methodInstance = getHandlerMethod(handler, args);
     // 设置响应拦截器
     setResponseHandler(methodInstance);
 

--- a/packages/client/test/react/useRetriableRequest.spec.tsx
+++ b/packages/client/test/react/useRetriableRequest.spec.tsx
@@ -64,7 +64,7 @@ describe('react => useRetriableRequest', () => {
       const { loading, error, onError, onComplete, onSuccess, onRetry, onFail } = useRetriableRequest(methodInstance);
       onRetry(event => {
         mockRetryFn();
-        expect(event.sendArgs).toStrictEqual([]);
+        expect(event.args).toStrictEqual([]);
         expect(event.method).toBe(methodInstance);
         expect(event.retryDelay).toBe(1000);
         expect(event.retryTimes).toBeLessThanOrEqual(3);
@@ -74,7 +74,7 @@ describe('react => useRetriableRequest', () => {
       onSuccess(mockSuccessFn);
       onFail(event => {
         mockFailFn();
-        expect(event.sendArgs).toStrictEqual([]);
+        expect(event.args).toStrictEqual([]);
         expect(event.error).toBeInstanceOf(Error);
         expect(event.method).toBe(methodInstance);
         expect(event.retryTimes).toBe(3);

--- a/packages/client/test/vue/core/functional/parallel-request.spec.ts
+++ b/packages/client/test/vue/core/functional/parallel-request.spec.ts
@@ -67,7 +67,7 @@ describe('parallel request', () => {
 
     const [firstEvent, secondEvent] = await Promise.all([firstPromise, secondPromise]);
     expect(firstEvent.method).toBe(Getter);
-    expect(firstEvent.sendArgs).toStrictEqual([]);
+    expect(firstEvent.args).toStrictEqual([]);
 
     const firstResponse = firstEvent.data;
     const secondResponse = secondEvent.data;

--- a/packages/client/test/vue/core/hooks/useFetcher.spec.ts
+++ b/packages/client/test/vue/core/hooks/useFetcher.spec.ts
@@ -122,7 +122,7 @@ describe('use useFetcher hook to fetch data', () => {
       fetch,
       onSuccess: onFetchSuccess
     } = useFetcher<FetcherType<typeof alova>>({
-      force({ sendArgs: [p1, p2] }) {
+      force({ args: [p1, p2] }) {
         mockFn();
         expect(p1).toBeTruthy();
         expect(p2).toBeFalsy();

--- a/packages/client/test/vue/core/hooks/useRequest-http.spec.ts
+++ b/packages/client/test/vue/core/hooks/useRequest-http.spec.ts
@@ -120,11 +120,11 @@ describe('use useRequest hook to send GET with vue', () => {
       expect(event.status).toBe('error');
       expect(event.error).toBe(error.value);
       expect(event.method).toBe(Get);
-      expect(event.sendArgs).toStrictEqual([]);
+      expect(event.args).toStrictEqual([]);
     });
     const errEvent = await untilCbCalled(onError);
     expect(errEvent.method).toBe(Get);
-    expect(errEvent.sendArgs).toStrictEqual([]);
+    expect(errEvent.args).toStrictEqual([]);
     expect(loading.value).toBeFalsy();
     expect(data.value).toBeUndefined();
     expect(downloading.value).toStrictEqual({ total: 0, loaded: 0 });
@@ -326,16 +326,16 @@ describe('use useRequest hook to send GET with vue', () => {
     const { data, send, onSuccess, onComplete } = useRequest(params => getGetter(params), {
       immediate: false
     });
-    onSuccess(({ data, sendArgs }) => {
-      expect(sendArgs).toHaveLength(1);
-      const obj = sendArgs[0];
+    onSuccess(({ data, args }) => {
+      expect(args).toHaveLength(1);
+      const obj = args[0];
       expect(data.path).toBe('/unit-test');
       expect(obj.a).toMatch(/~|\./);
       expect(obj.b).toMatch(/~|\./);
     });
-    onComplete(({ sendArgs }) => {
-      expect(sendArgs).toHaveLength(1);
-      const obj = sendArgs[0];
+    onComplete(({ args }) => {
+      expect(args).toHaveLength(1);
+      const obj = args[0];
       expect(obj.a).toMatch(/~|\./);
       expect(obj.b).toMatch(/~|\./);
     });
@@ -375,14 +375,14 @@ describe('use useRequest hook to send GET with vue', () => {
     });
 
     const mockFn = jest.fn();
-    onError(({ error, sendArgs }) => {
-      const index = sendArgs[0];
+    onError(({ error, args }) => {
+      const index = args[0];
       mockFn();
       expect(error.message).toMatch(/404/);
       expect(index.toString()).toMatch(/3|5/);
     });
-    onComplete(({ error, sendArgs }) => {
-      const index = sendArgs[0];
+    onComplete(({ error, args }) => {
+      const index = args[0];
       mockFn();
       expect(error.message).toMatch(/404/);
       expect(index.toString()).toMatch(/3|5/);
@@ -412,7 +412,7 @@ describe('use useRequest hook to send GET with vue', () => {
       force: event => {
         mockFn();
         expect(event).toBeInstanceOf(AlovaEventBase);
-        expect(event.sendArgs).toStrictEqual([1, 2, 3]);
+        expect(event.args).toStrictEqual([1, 2, 3]);
         return true;
       }
     });
@@ -437,7 +437,7 @@ describe('use useRequest hook to send GET with vue', () => {
 
     const { data, send } = useRequest(getGetterObj, {
       immediate: false,
-      force: ({ sendArgs: [force] }) => force
+      force: ({ args: [force] }) => force
     });
 
     setCache(getGetterObj, {

--- a/packages/client/test/vue/core/hooks/useWatcher.spec.ts
+++ b/packages/client/test/vue/core/hooks/useWatcher.spec.ts
@@ -871,7 +871,7 @@ describe('use useWatcher hook to send GET with vue', () => {
 
     const ctrlVal = ref(0);
     const { data, send, onSuccess } = useWatcher(() => getGetterObj, [ctrlVal], {
-      force: ({ sendArgs: [force] }) => force
+      force: ({ args: [force] }) => force
     });
 
     setCache(getGetterObj, {

--- a/packages/client/test/vue/useSQRequest.spec.ts
+++ b/packages/client/test/vue/useSQRequest.spec.ts
@@ -81,7 +81,7 @@ describe('vue => useSQRequest', () => {
     expect(scopedSQSuccessEvent.method).toBe(Get);
     expect(scopedSQSuccessEvent.data.total).toBe(300);
     expect(scopedSQSuccessEvent.data.list).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    expect(scopedSQSuccessEvent.sendArgs).toStrictEqual([]);
+    expect(scopedSQSuccessEvent.args).toStrictEqual([]);
     expect(!!scopedSQSuccessEvent.silentMethod).toBeTruthy();
 
     expect(beforePushMockFn).toHaveBeenCalledTimes(1);
@@ -90,7 +90,7 @@ describe('vue => useSQRequest', () => {
     expect(beforePushEvent.behavior).toBe('queue');
     expect(beforePushEvent.method).toBe(Get);
     expect(beforePushEvent.silentMethod).toBeInstanceOf(SilentMethod);
-    expect(beforePushEvent.sendArgs).toStrictEqual([]);
+    expect(beforePushEvent.args).toStrictEqual([]);
     expect(currentQueueStageBeforePush).toHaveLength(0);
 
     expect(pushedMockFn).toHaveBeenCalledTimes(1);
@@ -99,7 +99,7 @@ describe('vue => useSQRequest', () => {
     expect(pushedEvent.behavior).toBe('queue');
     expect(pushedEvent.method).toBe(Get);
     expect(pushedEvent.silentMethod).toBeInstanceOf(SilentMethod);
-    expect(pushedEvent.sendArgs).toStrictEqual([]);
+    expect(pushedEvent.args).toStrictEqual([]);
     expect(currentQueueStagePushed).toHaveLength(1);
     expect(currentQueueStagePushed[0]).toBe(pushedEvent.silentMethod);
 
@@ -110,7 +110,7 @@ describe('vue => useSQRequest', () => {
     expect(completedEvent.method).toBe(Get);
     expect(completedEvent.data.total).toBe(300);
     expect(completedEvent.data.list).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    expect(completedEvent.sendArgs).toStrictEqual([]);
+    expect(completedEvent.args).toStrictEqual([]);
     expect(!!completedEvent.silentMethod).toBeTruthy();
 
     expect(Object.keys(silentQueueMap[queue])).toHaveLength(0);
@@ -209,7 +209,7 @@ describe('vue => useSQRequest', () => {
     expect(scopedSQSuccessEvent.behavior).toBe('queue');
     expect(scopedSQSuccessEvent.data.total).toBe(300);
     expect(scopedSQSuccessEvent.data.list).toStrictEqual([8, 9, 10, 11, 12, 13, 14, 15]);
-    expect(scopedSQSuccessEvent.sendArgs).toStrictEqual([2, 8]);
+    expect(scopedSQSuccessEvent.args).toStrictEqual([2, 8]);
     expect(!!scopedSQSuccessEvent.silentMethod).toBeTruthy();
 
     expect(beforePushMockFn).toHaveBeenCalledTimes(1);
@@ -218,7 +218,7 @@ describe('vue => useSQRequest', () => {
     expect(beforePushEvent.method.url).toBe('/list');
     expect(beforePushEvent.method.config.params).toStrictEqual({ page: 2, pageSize: 8 });
     expect(beforePushEvent.silentMethod).toBeInstanceOf(SilentMethod);
-    expect(beforePushEvent.sendArgs).toStrictEqual([2, 8]);
+    expect(beforePushEvent.args).toStrictEqual([2, 8]);
 
     expect(pushedMockFn).toHaveBeenCalledTimes(1);
     const [pushedEvent] = pushedMockFn.mock.calls[0];
@@ -226,7 +226,7 @@ describe('vue => useSQRequest', () => {
     expect(pushedEvent.method.url).toBe('/list');
     expect(pushedEvent.method.config.params).toStrictEqual({ page: 2, pageSize: 8 });
     expect(pushedEvent.silentMethod).toBeInstanceOf(SilentMethod);
-    expect(pushedEvent.sendArgs).toStrictEqual([2, 8]);
+    expect(pushedEvent.args).toStrictEqual([2, 8]);
   });
 
   test('should emit onError immediately while request error and never retry', async () => {
@@ -249,7 +249,7 @@ describe('vue => useSQRequest', () => {
     expect(scopedSQErrorEvent).toBeInstanceOf(ScopedSQErrorEvent);
     expect(scopedSQErrorEvent.behavior).toBe('queue');
     expect(scopedSQErrorEvent.error.message).toBe('server error');
-    expect(scopedSQErrorEvent.sendArgs).toStrictEqual([]);
+    expect(scopedSQErrorEvent.args).toStrictEqual([]);
     expect(scopedSQErrorEvent.silentMethod).not.toBeUndefined();
     expect(silentQueueMap[queue]).toHaveLength(0); // 在队列中移除了
 
@@ -257,7 +257,7 @@ describe('vue => useSQRequest', () => {
     expect(completedEvent).toBeInstanceOf(ScopedSQCompleteEvent);
     expect(completedEvent.behavior).toBe('queue');
     expect(completedEvent.error.message).toBe('server error');
-    expect(completedEvent.sendArgs).toStrictEqual([]);
+    expect(completedEvent.args).toStrictEqual([]);
     expect(completedEvent.silentMethod).not.toBeUndefined();
   });
 
@@ -326,7 +326,7 @@ describe('vue => useSQRequest', () => {
       total: 300,
       list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     });
-    expect(scopedSQSuccessEvent.sendArgs).toStrictEqual([]);
+    expect(scopedSQSuccessEvent.args).toStrictEqual([]);
     expect(scopedSQSuccessEvent.method).not.toBeUndefined();
     expect(scopedSQSuccessEvent.silentMethod).toBeUndefined();
   });
@@ -366,7 +366,7 @@ describe('vue => useSQRequest', () => {
     expect(fallbackEvent.behavior).toBe('silent');
     expect(fallbackEvent.method).not.toBeUndefined();
     expect(fallbackEvent.silentMethod).toBeInstanceOf(SilentMethod);
-    expect(fallbackEvent.sendArgs).toStrictEqual([]);
+    expect(fallbackEvent.args).toStrictEqual([]);
   });
 
   test('should be change behavior when param behavior set to a function that return different value', async () => {
@@ -383,7 +383,7 @@ describe('vue => useSQRequest', () => {
     expect(event.data).toBeInstanceOf(Undefined);
     expect(event.data[symbolVDataId]).not.toBeUndefined();
     expect(event.behavior).toBe('silent');
-    expect(event.sendArgs).toStrictEqual([]);
+    expect(event.args).toStrictEqual([]);
 
     behaviorStr = 'static';
     send(1, 2, 3);
@@ -391,7 +391,7 @@ describe('vue => useSQRequest', () => {
     expect(data.value).toStrictEqual({ id: 1 });
     expect(event.data).toStrictEqual({ id: 1 });
     expect(event.behavior).toBe('static');
-    expect(event.sendArgs).toStrictEqual([1, 2, 3]);
+    expect(event.args).toStrictEqual([1, 2, 3]);
   });
 
   test('should be intercepted when has virtual data in method instance', async () => {
@@ -483,7 +483,7 @@ describe('vue => useSQRequest', () => {
     expect(event.behavior).toBe('silent');
     expect(event.method).not.toBeUndefined();
     expect(event.silentMethod).not.toBeUndefined();
-    expect(event.sendArgs).toStrictEqual([]);
+    expect(event.args).toStrictEqual([]);
     expect(data.value[symbolVDataId]).toBeTruthy();
     expect(dehydrateVData(event.data)).toBeUndefined();
     expect(dehydrateVData(data.value)).toBeUndefined();

--- a/packages/client/typings/clienthook/general.d.ts
+++ b/packages/client/typings/clienthook/general.d.ts
@@ -26,7 +26,7 @@ export interface AlovaEvent<AG extends AlovaGenerics> {
   /**
    * params from send function
    */
-  sendArgs: any[];
+  args: any[];
   /**
    * current method instance
    */

--- a/packages/client/typings/clienthook/hooks/useSQRequest.d.ts
+++ b/packages/client/typings/clienthook/hooks/useSQRequest.d.ts
@@ -82,7 +82,7 @@ export interface ScopedSQEvent<AG extends AlovaGenerics> extends SQEvent<AG> {
   /**
    * 通过send触发请求时传入的参数
    */
-  sendArgs: any[];
+  args: any[];
 }
 /** 局部成功事件 */
 export interface ScopedSQSuccessEvent<AG extends AlovaGenerics> extends ScopedSQEvent<AG> {

--- a/packages/client/typings/clienthook/hooks/useSSE.d.ts
+++ b/packages/client/typings/clienthook/hooks/useSSE.d.ts
@@ -68,9 +68,9 @@ export interface SSEExposure<AG extends AlovaGenerics, Data> {
   eventSource: ExportedState<EventSource | undefined, AG['StatesExport']>;
   /**
    * 手动发起请求。在使用 `immediate: true` 时该方法会自动触发
-   * @param sendArgs 请求参数，会传递给 method
+   * @param args 请求参数，会传递给 method
    */
-  send(...sendArgs: any[]): Promise<void>;
+  send(...args: any[]): Promise<void>;
   /**
    * 关闭连接
    */

--- a/packages/shared/src/event.ts
+++ b/packages/shared/src/event.ts
@@ -2,21 +2,21 @@ import { AlovaGenerics, Method } from '../../alova/typings';
 import { AlovaEvent } from '../../client/typings/clienthook';
 
 export class AlovaEventBase<AG extends AlovaGenerics> implements AlovaEvent<AG> {
-  readonly sendArgs: any[];
+  readonly args: any[];
 
   readonly method: Method<AG>;
 
-  constructor(method: Method<AG>, sendArgs: any[]) {
+  constructor(method: Method<AG>, args: any[]) {
     this.method = method;
-    this.sendArgs = sendArgs;
+    this.args = args;
   }
 
   clone() {
     return { ...this };
   }
 
-  static spawn(method: Method, sendArgs: any[]) {
-    return new AlovaEventBase(method, sendArgs);
+  static spawn(method: Method, args: any[]) {
+    return new AlovaEventBase(method, args);
   }
 }
 
@@ -26,7 +26,7 @@ export class AlovaSuccessEvent<AG extends AlovaGenerics> extends AlovaEventBase<
   readonly data: AG['Responded'];
 
   constructor(base: AlovaEventBase<AG>, data: AG['Responded'], fromCache: boolean) {
-    super(base.method, base.sendArgs);
+    super(base.method, base.args);
     this.data = data;
     this.fromCache = fromCache;
   }
@@ -36,7 +36,7 @@ export class AlovaErrorEvent<AG extends AlovaGenerics> extends AlovaEventBase<AG
   readonly error: any;
 
   constructor(base: AlovaEventBase<AG>, error: any) {
-    super(base.method, base.sendArgs);
+    super(base.method, base.args);
     this.error = error;
   }
 }
@@ -59,7 +59,7 @@ export class AlovaCompleteEvent<AG extends AlovaGenerics> extends AlovaEventBase
     fromCache: boolean,
     error: any
   ) {
-    super(base.method, base.sendArgs);
+    super(base.method, base.args);
     this.status = status;
     this.data = data;
     this.fromCache = status === 'error' ? false : fromCache;

--- a/packages/vue-options/README.md
+++ b/packages/vue-options/README.md
@@ -89,7 +89,7 @@ Below is a complete example.
       this.todoRequest$send();
       this.todoRequest$onSuccess(event => {
         event.data.match;
-        event.sendArgs.copyWithin;
+        event.args.copyWithin;
       });
       this.todoRequest$onSuccess(event => {
         console.log('success', event);

--- a/packages/vue-options/README.zh-CN.md
+++ b/packages/vue-options/README.zh-CN.md
@@ -89,7 +89,7 @@ export const getData = () => alovaInst.Get('/todolist');
       this.todoRequest$send();
       this.todoRequest$onSuccess(event => {
         event.data.match;
-        event.sendArgs.copyWithin;
+        event.args.copyWithin;
       });
       this.todoRequest$onSuccess(event => {
         console.log('success', event);


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

[Issue ID]
<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [ ] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [x] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

将全部的名字`sendArgs`改为`args`

[简要描述所做更改 / Describe the changes briefly]

**文档 / Docs**

[此次 PR 的文档 / Docs for this PR]

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

[描述测试结果 / Describe the test results.]
