### PR TITLE
fix: use the newest params to request modified in `beforeRequest`

### DIFF
--- a/.changeset/spicy-moose-pull.md
+++ b/.changeset/spicy-moose-pull.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+use the newest params to request modified in `beforeRequest`

--- a/packages/alova/test/browser/global/createAlova.spec.ts
+++ b/packages/alova/test/browser/global/createAlova.spec.ts
@@ -105,6 +105,40 @@ describe('createAlova', () => {
     expect(mockFn).toHaveBeenCalled();
   });
 
+  test('should use the newest params to request modified in `beforeRequest` hook', async () => {
+    const alova = createAlova({
+      requestAdapter: adapterFetch(),
+      beforeRequest: method => {
+        method.url = '/unit-test';
+        method.config.params = {
+          a: 7,
+          b: 8
+        };
+        method.config.headers = {
+          newHeader: 123
+        };
+        method.baseURL = 'http://localhost:3000';
+      },
+      responded: r => r.json()
+    });
+    const Get = alova.Get<Result>('/unknown', {
+      params: { a: 'a', b: 'str' },
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+    const result = await Get;
+    expect(result).toStrictEqual({
+      code: 200,
+      msg: '',
+      data: {
+        path: '/unit-test',
+        method: 'GET',
+        params: { a: '7', b: '8' }
+      }
+    });
+  });
+
   test('`beforeRequest` hook support async function', async () => {
     const alova = createAlova({
       baseURL: 'http://localhost:3000',

--- a/packages/alova/typings/index.d.ts
+++ b/packages/alova/typings/index.d.ts
@@ -600,9 +600,11 @@ export declare class Method<AG extends AlovaGenerics = any> {
   onUpload(progressHandler: ProgressHandler): () => void;
 }
 
-export interface MethodSnapshotContainer<AG extends AlovaGenerics> {
+export class MethodSnapshotContainer<AG extends AlovaGenerics> {
   records: Record<string, Set<Method<AG>>>;
+
   capacity: number;
+
   occupy: number;
   save(methodInstance: Method<AG>): void;
 


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

无

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

将`beforeRequest`中处理的最新请求参数进行请求

[简要描述所做更改 / Describe the changes briefly]

**文档 / Docs**

[此次 PR 的文档 / Docs for this PR]

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

[描述测试结果 / Describe the test results.]

passed