### PR TITLE
fix: incorrect type inference to statehook #493

### DIFF
--- a/.changeset/curly-students-melt.md
+++ b/.changeset/curly-students-melt.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+fix: incorrect type inference to statehook

--- a/packages/alova/typings/clienthook/hooks/tokenAuthentication.d.ts
+++ b/packages/alova/typings/clienthook/hooks/tokenAuthentication.d.ts
@@ -13,7 +13,7 @@ export type AlovaRequestAdapterUnified<
 // transform types StateHook and AlovaRequestAdapter to an AlovaGenerics
 export type StateHookAdapter2AG<SH extends StatesHook<any>, RA extends AlovaRequestAdapter<any, any, any>> =
   Parameters<RA>[1] extends Method<AlovaGenerics<infer R, infer T, infer RC, infer RE, infer RH>>
-    ? AlovaGenerics<R, T, RC, RE, RH, any, any, SH extends StatesHook[''] ? SE : unknown>
+    ? AlovaGenerics<R, T, RC, RE, RH, any, any, SH extends StatesHook<infer SE> ? SE : unknown>
     : never;
 
 export type AlovaResponded<SH extends StatesHook<any>, RA extends AlovaRequestAdapter<any, any, any>> = NonNullable<

--- a/packages/client/test/functions/createClientTokenAuthentication.spec.ts
+++ b/packages/client/test/functions/createClientTokenAuthentication.spec.ts
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { createClientTokenAuthentication } from '@/functions/tokenAuthentication/createTokenAuthentication';
 import { useRequest } from '@/index';
+import type { Equal } from '@alova/shared/types';
 import { Alova, createAlova, Method } from 'alova';
 import adapterFetch from 'alova/fetch';
 import VueHook, { type VueHookType } from 'alova/vue';
 import { delay } from 'msw';
 import { generateContinuousNumbers, Result, untilCbCalled } from 'root/testUtils';
+import type { Ref } from 'vue';
 import { MockRequestAdapter, mockRequestAdapter } from '../mockData';
 
 const baseURL = process.env.NODE_BASE_URL as string;
@@ -279,7 +281,7 @@ describe('createClientTokenAuthentication', () => {
     loginMethod.meta = {
       authRole: 'login'
     };
-    const { onSuccess } = useRequest(loginMethod);
+    const { onSuccess, data } = useRequest(loginMethod);
     onSuccess(() => {
       orderAry.push('useHook.onSuccess');
     });
@@ -300,6 +302,7 @@ describe('createClientTokenAuthentication', () => {
 
     await untilCbCalled(onLogoutSuccess);
     expect(orderAry).toStrictEqual(['logout', 'global.onSuccess', 'useHook.onSuccess']);
+    expect<Equal<typeof data, Ref<ListResponse>>>(true);
   });
 
   test('should refresh token first when it is expired', async () => {

--- a/packages/client/test/functions/createServerTokenAuthentication.spec.ts
+++ b/packages/client/test/functions/createServerTokenAuthentication.spec.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { createServerTokenAuthentication } from '@/functions/tokenAuthentication/createTokenAuthentication';
+import type { Equal } from '@alova/shared/types';
 import { Alova, createAlova, Method } from 'alova';
 import { useRequest } from 'alova/client';
 import adapterFetch from 'alova/fetch';
 import VueHook, { type VueHookType } from 'alova/vue';
 import { delay, generateContinuousNumbers, Result, untilCbCalled } from 'root/testUtils';
+import type { Ref } from 'vue';
 import { MockRequestAdapter, mockRequestAdapter } from '../mockData';
 
 const baseURL = process.env.NODE_BASE_URL as string;
@@ -277,7 +279,7 @@ describe('createServerTokenAuthentication', () => {
     loginMethod.meta = {
       authRole: 'login'
     };
-    const { onSuccess } = useRequest(loginMethod);
+    const { onSuccess, data } = useRequest(loginMethod);
     onSuccess(() => {
       orderAry.push('useHook.onSuccess');
     });
@@ -298,6 +300,7 @@ describe('createServerTokenAuthentication', () => {
 
     await untilCbCalled(onLogoutSuccess);
     expect(orderAry).toStrictEqual(['logout', 'global.onSuccess', 'useHook.onSuccess']);
+    expect<Equal<typeof data, Ref<ListResponse>>>(true);
   });
 
   test('should refresh token first on error event when it is expired', async () => {

--- a/packages/client/test/mockData.ts
+++ b/packages/client/test/mockData.ts
@@ -1,4 +1,5 @@
-import { createAlovaMockAdapter, defineMock } from '@alova/mock';
+import { createAlovaMockAdapter, defineMock, FetchRequestInit } from '@alova/mock';
+import { AlovaRequestAdapter } from 'alova';
 import { untilCbCalled } from 'root/testUtils';
 
 const total = 300;
@@ -200,4 +201,4 @@ export const mockRequestAdapter = createAlovaMockAdapter([mocks], {
   mockRequestLogger: false
 });
 
-export type MockRequestAdapter = typeof mockRequestAdapter;
+export type MockRequestAdapter = AlovaRequestAdapter<FetchRequestInit, BodyType, Record<string, string | number>>;

--- a/packages/client/typings/clienthook/hooks/tokenAuthentication.d.ts
+++ b/packages/client/typings/clienthook/hooks/tokenAuthentication.d.ts
@@ -13,7 +13,7 @@ export type AlovaRequestAdapterUnified<
 // transform types StateHook and AlovaRequestAdapter to an AlovaGenerics
 export type StateHookAdapter2AG<SH extends StatesHook<any>, RA extends AlovaRequestAdapter<any, any, any>> =
   Parameters<RA>[1] extends Method<AlovaGenerics<infer R, infer T, infer RC, infer RE, infer RH>>
-    ? AlovaGenerics<R, T, RC, RE, RH, any, any, SH extends StatesHook[''] ? SE : unknown>
+    ? AlovaGenerics<R, T, RC, RE, RH, any, any, SH extends StatesHook<infer SE> ? SE : 123123>
     : never;
 
 export type AlovaResponded<SH extends StatesHook<any>, RA extends AlovaRequestAdapter<any, any, any>> = NonNullable<

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -17,6 +17,8 @@ export type IsAny<T, P, N> = 0 extends 1 & T ? P : N;
  */
 export type IsUnknown<T, P, N> = IsAny<T, P, N> extends P ? N : unknown extends T ? P : N;
 
+export type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+
 export type UsePromiseExposure<T> = {
   promise: Promise<T>;
   resolve: (value: T | PromiseLike<T>) => void;


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

#493 

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

fix the incorrect type inference to statehook

**测试 / Testing**

ALL tests passed.