### PR TITLE
fix(react): uploading and downloading from usehooks do not update by calling send in react

### DIFF
--- a/.changeset/four-fishes-accept.md
+++ b/.changeset/four-fishes-accept.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+uploading and downloading from usehooks do not update by calling send in react

--- a/packages/client/src/hooks/core/implements/createRequestState.ts
+++ b/packages/client/src/hooks/core/implements/createRequestState.ts
@@ -121,7 +121,6 @@ export default function createRequestState<AG extends AlovaGenerics, Config exte
   hookInstance.fs = frontStates;
   hookInstance.em = eventManager;
   hookInstance.c = useHookConfig;
-  hookInstance.ro = referingObject;
 
   const hasWatchingStates = watchingStates !== undefinedValue;
   // 初始化请求事件


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

[Issue ID]

none

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

uploading and downloading from usehooks do not update by calling send in react

[简要描述所做更改 / Describe the changes briefly]

**文档 / Docs**

[此次 PR 的文档 / Docs for this PR]

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

[描述测试结果 / Describe the test results.]

all passed
