### PR TITLE
fix: correct key listData to data in usePagination

### DIFF
--- a/.changeset/metal-radios-clean.md
+++ b/.changeset/metal-radios-clean.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+modify key `listData` to `data` in `usePagination`

--- a/packages/alova/typings/clienthook/general.d.ts
+++ b/packages/alova/typings/clienthook/general.d.ts
@@ -5,6 +5,7 @@ import {
   AlovaGenerics,
   FetchRequestState,
   FrontRequestState,
+  MergedStatesMap,
   Method,
   Progress,
   ReferingObject,
@@ -226,7 +227,7 @@ export interface Hook {
   m?: Method;
 
   /** saveStatesFns */
-  sf: ((frontStates: FrontRequestState) => void)[];
+  sf: ((frontStates: MergedStatesMap) => void)[];
 
   /** removeStatesFns */
   rf: (() => void)[];
@@ -255,4 +256,7 @@ export interface Hook {
 
   /** refering object */
   ro: ReferingObject;
+
+  /** managed states */
+  ms: MergedStatesMap;
 }

--- a/packages/alova/typings/clienthook/hooks/updateState.d.ts
+++ b/packages/alova/typings/clienthook/hooks/updateState.d.ts
@@ -20,6 +20,6 @@ export type UpdateStateCollection<Responded> = {
  * @returns is updated
  */
 export declare function updateState<Responded>(
-  matcher: Method<AlovaGenerics<Responded>>,
+  matcher: Method<AlovaGenerics<Responded extends unknown ? any : Responded>>,
   handleUpdate: UpdateStateCollection<Responded>['data'] | UpdateStateCollection<Responded>
 ): Promise<boolean>;

--- a/packages/alova/typings/index.d.ts
+++ b/packages/alova/typings/index.d.ts
@@ -1,4 +1,5 @@
 import { EventManager } from '@alova/shared/createEventManager';
+import { FrameworkState } from '@alova/shared/FrameworkState';
 
 export interface AlovaGenerics<
   R = any,
@@ -207,11 +208,12 @@ export interface FrontRequestState<L = any, R = any, E = any, D = any, U = any> 
   data: R;
 }
 
+export type MergedStatesMap = Record<string, FrameworkState<any, string>>;
 export interface EffectRequestParams<E> {
   handler: (...args: any[]) => void;
   removeStates: () => void;
-  saveStates: (frontStates: FrontRequestState) => void;
-  frontStates: FrontRequestState;
+  saveStates: (frontStates: MergedStatesMap) => void;
+  frontStates: MergedStatesMap;
   watchingStates?: E[];
   immediate: boolean;
 }

--- a/packages/client/src/hooks/core/implements/createHook.ts
+++ b/packages/client/src/hooks/core/implements/createHook.ts
@@ -39,5 +39,8 @@ export default <AG extends AlovaGenerics>(
     c,
 
     /** referingObject */
-    ro
+    ro,
+
+    /** managedStates */
+    ms: {}
   }) as Hook;

--- a/packages/client/src/hooks/core/implements/stateCache.ts
+++ b/packages/client/src/hooks/core/implements/stateCache.ts
@@ -1,17 +1,10 @@
-import { FrameworkState } from '@alova/shared/FrameworkState';
 import { deleteAttr } from '@alova/shared/vars';
-import type { FrontRequestState, Progress } from 'alova';
+import type { MergedStatesMap } from 'alova';
 import { Hook } from '~/typings/clienthook';
 
 // 状态数据缓存
 interface CacheItem {
-  s: FrontRequestState<
-    FrameworkState<boolean, 'loading'>,
-    FrameworkState<any, 'data'>,
-    FrameworkState<Error | undefined, 'error'>,
-    FrameworkState<Progress, 'downloading'>,
-    FrameworkState<Progress, 'uploading'>
-  >;
+  s: MergedStatesMap;
   h: Hook;
 }
 const stateCache: Record<string, Record<string, CacheItem>> = {};
@@ -33,7 +26,7 @@ export const getStateCache = (namespace: string, key: string) => {
  * @param key 请求key值
  * @param data 缓存数据
  */
-export const setStateCache = (namespace: string, key: string, data: FrontRequestState, hookInstance: Hook) => {
+export const setStateCache = (namespace: string, key: string, data: MergedStatesMap, hookInstance: Hook) => {
   const cachedState = (stateCache[namespace] = stateCache[namespace] || {});
   cachedState[key] = {
     s: data,

--- a/packages/client/src/hooks/core/implements/useHookToSendRequest.ts
+++ b/packages/client/src/hooks/core/implements/useHookToSendRequest.ts
@@ -9,7 +9,7 @@ import {
   sloughConfig
 } from '@alova/shared/function';
 import { falseValue, promiseResolve, promiseThen, pushItem, trueValue, undefinedValue } from '@alova/shared/vars';
-import { AlovaGenerics, FrontRequestState, Method, Progress, queryCache } from 'alova';
+import { AlovaGenerics, Method, Progress, queryCache } from 'alova';
 import {
   AlovaFetcherMiddleware,
   AlovaFrontMiddleware,
@@ -40,7 +40,7 @@ export default function useHookToSendRequest<AG extends AlovaGenerics>(
 ) {
   const currentHookAssert = coreHookAssert(hookInstance.ht);
   let methodInstance = getHandlerMethod(methodHandler, currentHookAssert, sendCallingArgs);
-  const { fs: frontStates, ht: hookType, c: useHookConfig } = hookInstance;
+  const { fs: frontStates, ht: hookType, c: useHookConfig, ms: managedStates } = hookInstance;
   const { loading: loadingState, data: dataState, error: errorState } = frontStates;
   const isFetcher = hookType === EnumHookType.USE_FETCHER;
   const { force: forceRequest = falseValue, middleware = defaultMiddleware } = useHookConfig as
@@ -67,8 +67,8 @@ export default function useHookToSendRequest<AG extends AlovaGenerics>(
     let controlledLoading = falseValue;
     if (!isFetcher) {
       // 将初始状态存入缓存以便后续更新
-      saveStates = (frontStates: FrontRequestState) => setStateCache(id, methodKey, frontStates, hookInstance);
-      saveStates(frontStates);
+      saveStates = frontStates => setStateCache(id, methodKey, frontStates, hookInstance);
+      saveStates({ ...frontStates, ...managedStates });
 
       // 设置状态移除函数，将会传递给hook内的effectRequest，它将被设置在组件卸载时调用
       removeStates = () => removeStateCache(id, methodKey);

--- a/packages/client/src/hooks/pagination/usePagination.ts
+++ b/packages/client/src/hooks/pagination/usePagination.ts
@@ -87,6 +87,7 @@ export default <AG extends AlovaGenerics, ListData extends unknown[]>(
   // 初始化fetcher
   const fetchStates = useFetcher<FetcherType<Alova<AG>>>({
     __referingObj: referingObject,
+    updateState: falseValue,
     force: ({ args }) => args[0]
   });
   const { loading, fetch, abort: abortFetch, onSuccess: onFetchSuccess } = fetchStates;
@@ -126,10 +127,7 @@ export default <AG extends AlovaGenerics, ListData extends unknown[]>(
     __referingObj: referingObject,
     immediate,
     initialData,
-    managedStates: {
-      ...objectify([page, pageSize, total], 's'),
-      listData: data.s
-    },
+    managedStates: objectify([data, page, pageSize, total], 's'),
     middleware(ctx, next) {
       (middleware as any)(
         {

--- a/packages/client/src/updateState.ts
+++ b/packages/client/src/updateState.ts
@@ -11,9 +11,9 @@ import { getStateCache } from './hooks/core/implements/stateCache';
  * @param handleUpdate 更新回调
  * @returns 是否更新成功，未找到对应的状态时不会更新成功
  */
-export default async function updateState<AG extends AlovaGenerics>(
-  matcher: Method<AG>,
-  handleUpdate: ((data: AG['Responded']) => any) | UpdateStateCollection<AG['Responded']>
+export default async function updateState<Responded = unknown>(
+  matcher: Method<AlovaGenerics<Responded extends unknown ? any : Responded>>,
+  handleUpdate: ((data: Responded) => any) | UpdateStateCollection<Responded>
 ) {
   let updated = falseValue;
 
@@ -24,7 +24,7 @@ export default async function updateState<AG extends AlovaGenerics>(
     const { id } = getContext(matcher);
     const { s: frontStates, h: hookInstance } = getStateCache(id, methodKey);
     const updateStateCollection = isFn(handleUpdate)
-      ? ({ data: handleUpdate } as UpdateStateCollection<AG['Responded']>)
+      ? ({ data: handleUpdate } as UpdateStateCollection<Responded>)
       : handleUpdate;
 
     let updatedDataColumnData = undefinedValue as any;
@@ -32,7 +32,6 @@ export default async function updateState<AG extends AlovaGenerics>(
       // 循环遍历更新数据，并赋值给受监管的状态
       forEach(objectKeys(updateStateCollection), stateName => {
         coreAssert(stateName in frontStates, `state named \`${stateName}\` is not found`);
-        coreAssert(!objectKeys(frontStates).slice(-4).includes(stateName), 'can not update preset states');
         const targetStateProxy = frontStates[stateName as keyof typeof frontStates];
         let updatedData = updateStateCollection[stateName as keyof typeof updateStateCollection](targetStateProxy.v);
 

--- a/packages/client/test/react/usePagination.spec.tsx
+++ b/packages/client/test/react/usePagination.spec.tsx
@@ -1,5 +1,5 @@
 import { mockRequestAdapter, setMockListData, setMockListWithSearchData, setMockShortListData } from '#/mockData';
-import { accessAction, actionDelegationMiddleware } from '@/index';
+import { accessAction, actionDelegationMiddleware, updateState } from '@/index';
 import { GeneralFn } from '@alova/shared/types';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -1637,6 +1637,46 @@ describe('react => usePagination', () => {
       expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify(currentList));
       expect(screen.getByRole('total')).toHaveTextContent('300');
       expect(successMockFn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  test('should update state data when call `updateState` function', async () => {
+    const initialPageSize = 4;
+    render(
+      <Pagination
+        getter={getter1}
+        paginationConfig={{
+          data: (res: any) => res.list,
+          append: true,
+          initialPageSize
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify([0, 1, 2, 3]));
+    });
+
+    let updated: boolean;
+    delay()
+      .then(() =>
+        updateState<number[]>(getter1(1, initialPageSize), {
+          data: list => [...list, 100, 200],
+          total: old => old + 10
+        })
+      )
+      .then(res => {
+        updated = res;
+      });
+    await waitFor(() => {
+      expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify([0, 1, 2, 3, 100, 200]));
+      expect(screen.getByRole('total')).toHaveTextContent('310');
+      expect(updated).toBeTruthy();
+    });
+
+    delay().then(() => updateState<number[]>(getter1(1, initialPageSize), list => [...list, 300]));
+    await waitFor(() => {
+      expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify([0, 1, 2, 3, 100, 200, 300]));
     });
   });
 });

--- a/packages/client/test/react/useRetriableRequest.spec.tsx
+++ b/packages/client/test/react/useRetriableRequest.spec.tsx
@@ -99,7 +99,7 @@ describe('react => useRetriableRequest', () => {
         expect(mockErrorFn).toHaveBeenCalledTimes(4);
         expect(mockRetryFn).toHaveBeenCalledTimes(3);
         expect(mockCompleteFn).toHaveBeenCalledTimes(4);
-        expect(mockSuccessFn).not.toBeCalled();
+        expect(mockSuccessFn).not.toHaveBeenCalled();
         expect(mockFailFn).toHaveBeenCalledTimes(1);
         /**
          * loading defaults to false (even if set immediate to true)
@@ -149,7 +149,7 @@ describe('react => useRetriableRequest', () => {
         expect(mockErrorFn).toHaveBeenCalledTimes(1);
         expect(mockCompleteFn).toHaveBeenCalledTimes(2);
         expect(mockSuccessFn).toHaveBeenCalledTimes(1);
-        expect(mockFailFn).not.toBeCalled();
+        expect(mockFailFn).not.toHaveBeenCalled();
       },
       {
         timeout: 4000
@@ -198,7 +198,7 @@ describe('react => useRetriableRequest', () => {
         expect(mockRetryFn).toHaveBeenCalledTimes(2);
         expect(mockErrorFn).toHaveBeenCalledTimes(3);
         expect(mockCompleteFn).toHaveBeenCalledTimes(3);
-        expect(mockSuccessFn).not.toBeCalled();
+        expect(mockSuccessFn).not.toHaveBeenCalled();
         expect(mockFailFn).toHaveBeenCalledTimes(1);
       },
       {
@@ -253,7 +253,7 @@ describe('react => useRetriableRequest', () => {
         expect(mockRetryFn).toHaveBeenCalledTimes(2);
         expect(mockErrorFn).toHaveBeenCalledTimes(3);
         expect(mockCompleteFn).toHaveBeenCalledTimes(3);
-        expect(mockSuccessFn).not.toBeCalled();
+        expect(mockSuccessFn).not.toHaveBeenCalled();
         expect(mockFailFn).toHaveBeenCalledTimes(1);
       },
       {
@@ -343,11 +343,11 @@ describe('react => useRetriableRequest', () => {
     render((<Page />) as ReactElement<any, any>);
     await untilCbCalled(setTimeout, 200);
     await screen.findByText(/loaded/);
-    expect(mockRetryFn).not.toBeCalled();
-    expect(mockErrorFn).not.toBeCalled();
-    expect(mockCompleteFn).not.toBeCalled();
-    expect(mockSuccessFn).not.toBeCalled();
-    expect(mockFailFn).not.toBeCalled();
+    expect(mockRetryFn).not.toHaveBeenCalled();
+    expect(mockErrorFn).not.toHaveBeenCalled();
+    expect(mockCompleteFn).not.toHaveBeenCalled();
+    expect(mockSuccessFn).not.toHaveBeenCalled();
+    expect(mockFailFn).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('btn'));
     await waitFor(
@@ -355,7 +355,7 @@ describe('react => useRetriableRequest', () => {
         expect(mockRetryFn).toHaveBeenCalledTimes(2);
         expect(mockErrorFn).toHaveBeenCalledTimes(3);
         expect(mockCompleteFn).toHaveBeenCalledTimes(3);
-        expect(mockSuccessFn).not.toBeCalled();
+        expect(mockSuccessFn).not.toHaveBeenCalled();
         expect(mockFailFn).toHaveBeenCalledTimes(1);
       },
       {
@@ -399,10 +399,10 @@ describe('react => useRetriableRequest', () => {
     render((<Page />) as ReactElement<any, any>);
     await waitFor(
       () => {
-        expect(mockRetryFn).not.toBeCalled(); // 第一次重试前停止了重试
+        expect(mockRetryFn).not.toHaveBeenCalled(); // 第一次重试前停止了重试
         expect(mockErrorFn).toHaveBeenCalledTimes(1); // 请求失败一次
         expect(mockCompleteFn).toHaveBeenCalledTimes(1); // 请求失败一次
-        expect(mockSuccessFn).not.toBeCalled();
+        expect(mockSuccessFn).not.toHaveBeenCalled();
         expect(mockFailFn).toHaveBeenCalledTimes(1); // 手动停止重试也将会立即触发fail事件
       },
       { timeout: 4000 }
@@ -576,7 +576,7 @@ describe('react => useRetriableRequest', () => {
         expect(mockErrorFn).toHaveBeenCalledTimes(4);
         expect(mockRetryFn).toHaveBeenCalledTimes(3);
         expect(mockCompleteFn).toHaveBeenCalledTimes(4);
-        expect(mockSuccessFn).not.toBeCalled();
+        expect(mockSuccessFn).not.toHaveBeenCalled();
         expect(mockFailFn).toHaveBeenCalledTimes(1);
         /**
          * loading defaults to false (even if set immediate to true)
@@ -597,7 +597,7 @@ describe('react => useRetriableRequest', () => {
         expect(mockErrorFn).toHaveBeenCalledTimes(8);
         expect(mockRetryFn).toHaveBeenCalledTimes(6);
         expect(mockCompleteFn).toHaveBeenCalledTimes(8);
-        expect(mockSuccessFn).not.toBeCalled();
+        expect(mockSuccessFn).not.toHaveBeenCalled();
         expect(mockFailFn).toHaveBeenCalledTimes(2);
         expect(mockLoadingChangeFn).toHaveBeenCalledTimes(5);
       },

--- a/packages/client/test/vue/core/functional/update-state.spec.ts
+++ b/packages/client/test/vue/core/functional/update-state.spec.ts
@@ -97,13 +97,6 @@ describe('update cached response data by user in vue', () => {
     });
     await untilCbCalled(onSuccess);
 
-    // 预设状态不能更新
-    await expect(
-      updateState(Get, {
-        loading: () => true
-      })
-    ).rejects.toThrow('can not update preset states');
-
     // 非状态数据不能更新
     await expect(
       updateState(Get, {

--- a/packages/client/test/vue/usePagination.spec.ts
+++ b/packages/client/test/vue/usePagination.spec.ts
@@ -1630,7 +1630,6 @@ describe('vue => usePagination', () => {
     expect(fetchCompletedMockFn).toHaveBeenCalled();
   });
 
-  jest.setTimeout(1000000);
   test('should update state data when call `updateState` function', async () => {
     const initialPageSize = 4;
     render(Pagination, {
@@ -1648,14 +1647,26 @@ describe('vue => usePagination', () => {
       expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify([0, 1, 2, 3]));
     });
 
-    const updated = await updateState(getter1(1, initialPageSize), {
-      listData: (list: number[]) => [...list, 100, 200],
-      total: old => old + 10
-    });
+    let updated: boolean;
+    delay()
+      .then(() =>
+        updateState<number[]>(getter1(1, initialPageSize), {
+          data: list => [...list, 100, 200],
+          total: old => old + 10
+        })
+      )
+      .then(res => {
+        updated = res;
+      });
     await waitFor(() => {
       expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify([0, 1, 2, 3, 100, 200]));
       expect(screen.getByRole('total')).toHaveTextContent('310');
       expect(updated).toBeTruthy();
+    });
+
+    delay().then(() => updateState<number[]>(getter1(1, initialPageSize), list => [...list, 300]));
+    await waitFor(() => {
+      expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify([0, 1, 2, 3, 100, 200, 300]));
     });
   });
 });

--- a/packages/client/typings/clienthook/general.d.ts
+++ b/packages/client/typings/clienthook/general.d.ts
@@ -5,6 +5,7 @@ import {
   AlovaGenerics,
   FetchRequestState,
   FrontRequestState,
+  MergedStatesMap,
   Method,
   Progress,
   ReferingObject,
@@ -226,7 +227,7 @@ export interface Hook {
   m?: Method;
 
   /** saveStatesFns */
-  sf: ((frontStates: FrontRequestState) => void)[];
+  sf: ((frontStates: MergedStatesMap) => void)[];
 
   /** removeStatesFns */
   rf: (() => void)[];
@@ -255,4 +256,7 @@ export interface Hook {
 
   /** refering object */
   ro: ReferingObject;
+
+  /** managed states */
+  ms: MergedStatesMap;
 }

--- a/packages/client/typings/clienthook/hooks/updateState.d.ts
+++ b/packages/client/typings/clienthook/hooks/updateState.d.ts
@@ -20,6 +20,6 @@ export type UpdateStateCollection<Responded> = {
  * @returns is updated
  */
 export declare function updateState<Responded>(
-  matcher: Method<AlovaGenerics<Responded>>,
+  matcher: Method<AlovaGenerics<Responded extends unknown ? any : Responded>>,
   handleUpdate: UpdateStateCollection<Responded>['data'] | UpdateStateCollection<Responded>
 ): Promise<boolean>;


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

none

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

correct key `listData` to `data` in usePagination

**文档 / Docs**

[此次 PR 的文档 / Docs for this PR]

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

[描述测试结果 / Describe the test results.]

all passed