### PR TITLE
修复 `export = xxx` 的写法在 typescript 5.6.x 下报错的问题

### DIFF
--- a/packages/alova/typings/fetch.d.ts
+++ b/packages/alova/typings/fetch.d.ts
@@ -8,4 +8,4 @@ export type FetchRequestInit = Omit<RequestInit, 'body' | 'headers' | 'method'>;
 export type FetchRequestAdapter = AlovaRequestAdapter<FetchRequestInit, Response, Headers>;
 
 declare function adapterFetch(): FetchRequestAdapter;
-export = adapterFetch;
+export default adapterFetch;


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

[539](https://github.com/alovajs/alova/issues/539)

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [ ] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

修复 `export = xxx` 的写法在 typescript 5.6.x 下报错:
```
alova/typings/fetch"' has no default export
```

**文档 / Docs**

无文档

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

- 使用 typescript 5.6.x 测试，错误消失。
- `pnpm test` 测试正常
