### PR TITLE
fix: unified the request that the types contain request body to be `undefined`

### DIFF
--- a/.changeset/shiny-balloons-sit.md
+++ b/.changeset/shiny-balloons-sit.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+unified the request that the types contain request body to be `undefined`

--- a/packages/alova/src/alova.ts
+++ b/packages/alova/src/alova.ts
@@ -82,7 +82,7 @@ export class Alova<AG extends AlovaGenerics> {
 
   Post<Responded = unknown, Transformed = unknown>(
     url: string,
-    data: RequestBody = {},
+    data?: RequestBody,
     config?: AlovaMethodCreateConfig<AG, Responded, Transformed>
   ) {
     return newInstance(
@@ -97,7 +97,7 @@ export class Alova<AG extends AlovaGenerics> {
 
   Delete<Responded = unknown, Transformed = unknown>(
     url: string,
-    data: RequestBody = {},
+    data?: RequestBody,
     config?: AlovaMethodCreateConfig<AG, Responded, Transformed>
   ) {
     return newInstance(
@@ -112,7 +112,7 @@ export class Alova<AG extends AlovaGenerics> {
 
   Put<Responded = unknown, Transformed = unknown>(
     url: string,
-    data: RequestBody = {},
+    data?: RequestBody,
     config?: AlovaMethodCreateConfig<AG, Responded, Transformed>
   ) {
     return newInstance(
@@ -134,7 +134,7 @@ export class Alova<AG extends AlovaGenerics> {
 
   Patch<Responded = unknown, Transformed = unknown>(
     url: string,
-    data: RequestBody = {},
+    data?: RequestBody,
     config?: AlovaMethodCreateConfig<AG, Responded, Transformed>
   ) {
     return newInstance(

--- a/packages/alova/test/browser/behavior/l1Cache.spec.ts
+++ b/packages/alova/test/browser/behavior/l1Cache.spec.ts
@@ -44,7 +44,7 @@ describe('l1cache cache data', () => {
       path: '/unit-test',
       method: 'POST',
       params: {},
-      data: {}
+      data: ''
     });
 
     // the `cacheFor` also set to an object
@@ -74,7 +74,7 @@ describe('l1cache cache data', () => {
       path: '/unit-test',
       method: 'POST',
       params: {},
-      data: {}
+      data: ''
     });
   });
 
@@ -102,7 +102,7 @@ describe('l1cache cache data', () => {
       path: '/unit-test',
       method: 'POST',
       params: {},
-      data: {}
+      data: ''
     });
 
     // the `cacheFor` also set to an object
@@ -132,7 +132,7 @@ describe('l1cache cache data', () => {
       path: '/unit-test',
       method: 'POST',
       params: {},
-      data: {}
+      data: ''
     });
   });
 
@@ -167,7 +167,7 @@ describe('l1cache cache data', () => {
       path: '/unit-test',
       method: 'POST',
       params: {},
-      data: {}
+      data: ''
     });
     expect(expireFn).toHaveBeenCalledWith(Post, 'memory');
   });

--- a/packages/alova/test/browser/behavior/l2Cache.spec.ts
+++ b/packages/alova/test/browser/behavior/l2Cache.spec.ts
@@ -35,13 +35,13 @@ describe('l2cache cache data', () => {
       path: '/unit-test',
       method: 'POST',
       params: {},
-      data: {}
+      data: ''
     });
     expect(await queryCache(Post1, { policy: 'l2' })).toStrictEqual({
       path: '/unit-test',
       method: 'POST',
       params: {},
-      data: {}
+      data: ''
     });
 
     // POST is cached
@@ -92,7 +92,7 @@ describe('l2cache cache data', () => {
       path: '/unit-test',
       method: 'POST',
       params: {},
-      data: {}
+      data: ''
     });
     expect(expireFn).toHaveBeenCalledTimes(2);
   });
@@ -120,7 +120,7 @@ describe('l2cache cache data', () => {
       path: '/unit-test',
       method: 'POST',
       params: {},
-      data: {}
+      data: ''
     });
     expect(expireFn).toHaveBeenCalledTimes(2);
   });

--- a/packages/alova/test/browser/global/methodInstance.spec.ts
+++ b/packages/alova/test/browser/global/methodInstance.spec.ts
@@ -365,6 +365,32 @@ describe('method instance', () => {
     expect(res.params).toStrictEqual({ a: 'a', b: 'str' });
   });
 
+  test('should the request body will be `undefined` initially', async () => {
+    const methodGet = alova.Get('/unit-test');
+    const methodPost = alova.Post('/unit-test');
+    const methodHead = alova.Head('/unit-test');
+    const methodPut = alova.Put('/unit-test');
+    const methodDelete = alova.Delete('/unit-test');
+    const methodPatch = alova.Patch('/unit-test');
+    const methodOptions = alova.Options('/unit-test');
+    expect(methodGet.data).toBeUndefined();
+    expect(methodPost.data).toBeUndefined();
+    expect(methodHead.data).toBeUndefined();
+    expect(methodPut.data).toBeUndefined();
+    expect(methodDelete.data).toBeUndefined();
+    expect(methodPatch.data).toBeUndefined();
+    expect(methodOptions.data).toBeUndefined();
+
+    const methodPost2 = alova.Post('/unit-test', {});
+    const methodPut2 = alova.Put('/unit-test', {});
+    const methodDelete2 = alova.Delete('/unit-test', {});
+    const methodPatch2 = alova.Patch('/unit-test', {});
+    expect(methodPost2.data).toStrictEqual({});
+    expect(methodPut2.data).toStrictEqual({});
+    expect(methodDelete2.data).toStrictEqual({});
+    expect(methodPatch2.data).toStrictEqual({});
+  });
+
   test('it can customize the method key', async () => {
     const method1 = alova.Get('/unit-test');
     method1.key = 'method1-key';


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

none

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

unified the request that the types contain request body to be `undefined`

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

all passed