### PR TITLE
fix(alova/fetch): fix that cannot found alova/fetch in ts5.6

### DIFF
--- a/.changeset/itchy-apricots-tan.md
+++ b/.changeset/itchy-apricots-tan.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+fix that cannot found alova/fetch in ts5.6

--- a/packages/alova/package.json
+++ b/packages/alova/package.json
@@ -79,7 +79,10 @@
       "default": "./dist/serverhook/index.esm.js"
     },
     "./fetch": {
-      "types": "./typings/fetch.d.ts",
+      "types": {
+        "require": "./typings/fetch.d.cts",
+        "default": "./typings/fetch.d.ts"
+      },
       "require": "./dist/adapter/fetch.common.cjs",
       "default": "./dist/adapter/fetch.esm.js"
     },

--- a/packages/alova/typings/fetch.d.cts
+++ b/packages/alova/typings/fetch.d.cts
@@ -1,0 +1,13 @@
+import { AlovaRequestAdapter } from '.';
+
+declare namespace FetchTypes {
+  type FetchRequestInit = Omit<RequestInit, 'body' | 'headers' | 'method'>;
+
+  /**
+   * adapterFetch请求适配器
+   */
+  type FetchRequestAdapter = AlovaRequestAdapter<FetchRequestInit, Response, Headers>;
+}
+
+declare function adapterFetch(): FetchTypes.FetchRequestAdapter;
+export = FetchTypes;

--- a/packages/alova/typings/fetch.d.ts
+++ b/packages/alova/typings/fetch.d.ts
@@ -8,4 +8,4 @@ export type FetchRequestInit = Omit<RequestInit, 'body' | 'headers' | 'method'>;
 export type FetchRequestAdapter = AlovaRequestAdapter<FetchRequestInit, Response, Headers>;
 
 declare function adapterFetch(): FetchRequestAdapter;
-export = adapterFetch;
+export default adapterFetch;


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

fix #539

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

[简要描述所做更改 / Describe the changes briefly]

**文档 / Docs**

[此次 PR 的文档 / Docs for this PR]

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

all passed
