### PR TITLE
fix: export `statesHookHelper` from `alova/client`

### DIFF
--- a/.changeset/five-dolls-add.md
+++ b/.changeset/five-dolls-add.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+export `statesHookHelper` from `alova/client`

--- a/packages/alova/typings/clienthook/helper.d.ts
+++ b/packages/alova/typings/clienthook/helper.d.ts
@@ -1,0 +1,86 @@
+import { FrameworkReadableState, FrameworkState, GeneralFn, GeneralState } from '@alova/shared';
+import type { AlovaGenerics, EffectRequestParams, ReferingObject, StatesExport, StatesHook } from 'alova';
+import { ExportedComputed, ExportedState } from './general';
+
+type ActualStateTranslator<AG extends AlovaGenerics, StateProxy extends FrameworkReadableState<any, string>> =
+  StateProxy extends FrameworkState<any, string>
+    ? ExportedState<StateProxy['v'], AG['StatesExport']>
+    : ExportedComputed<StateProxy['v'], AG['StatesExport']>;
+type CompletedExposingProvider<AG extends AlovaGenerics, O extends Record<string | number | symbol, any>> = {
+  [K in keyof O]: O[K] extends FrameworkReadableState<any, string>
+    ? ActualStateTranslator<AG, O[K]>
+    : K extends `on${infer eventUnused}`
+      ? (...args: Parameters<O[K]>) => CompletedExposingProvider<AG, O>
+      : O[K];
+};
+
+/**
+ * create simple and unified, framework-independent states creators and handlers.
+ * @param statesHook states hook from `promiseStatesHook` function of alova
+ * @param referingObject refering object exported from `promiseStatesHook` function
+ * @returns simple and unified states creators and handlers
+ */
+// eslint-disable-next-line
+export declare function statesHookHelper<AG extends AlovaGenerics>(
+  statesHook: StatesHook<StatesExport<unknown>>,
+  referingObject?: ReferingObject
+): {
+  create: <Data, Key extends string>(initialValue: Data, key: Key) => FrameworkState<Data, Key>;
+  computed: <Data, Key extends string>(
+    getter: () => Data,
+    depList: (GeneralState | FrameworkReadableState<any, string>)[],
+    key: Key
+  ) => FrameworkReadableState<Data, Key>;
+  effectRequest: (effectRequestParams: EffectRequestParams<any>) => void;
+  ref: <Data>(initialValue: Data) => {
+    current: Data;
+  };
+  memorize: <Callback extends GeneralFn>(fn: Callback) => Callback;
+  watch: (source: (GeneralState | FrameworkReadableState<any, string>)[], callback: () => void) => void;
+  onMounted: (callback: () => void) => void;
+  onUnmounted: (callback: () => void) => void;
+  /**
+   * refering object that sharing some value with this object.
+   */
+  __referingObj: ReferingObject;
+  /**
+   * expose provider for specified use hook.
+   * @param object object that contains state proxy, framework state, operating function and event binder.
+   * @returns provider component.
+   */
+  exposeProvider: <O extends Record<string | number | symbol, any>>(
+    object: O
+  ) => CompletedExposingProvider<
+    AG,
+    O & {
+      __referingObj: ReferingObject;
+      update: (newStates: { [K in keyof O]?: any }) => void;
+      __proxyState: <K extends keyof O>(key: K) => any;
+    }
+  >;
+  /**
+   * transform state proxies to object.
+   * @param states proxy array of framework states
+   * @param filterKey filter key of state proxy
+   * @returns an object that contains the states of target form
+   */
+  objectify: <S extends FrameworkReadableState<any, string>[], Key extends 's' | 'v' | 'e' | undefined = undefined>(
+    states: S,
+    filterKey?: Key
+  ) => {
+    [K in S[number]['k']]: Key extends undefined
+      ? Extract<
+          S[number],
+          {
+            k: K;
+          }
+        >
+      : Extract<
+          S[number],
+          {
+            k: K;
+          }
+        >[NonNullable<Key>];
+  };
+  transformState2Proxy: <Key extends string>(state: GeneralState<any>, key: Key) => FrameworkState<any, Key>;
+};

--- a/packages/alova/typings/clienthook/index.d.ts
+++ b/packages/alova/typings/clienthook/index.d.ts
@@ -1,4 +1,5 @@
 export * from './general';
+export * from './helper';
 export * from './hooks/actionDelegationMiddleware';
 export * from './hooks/tokenAuthentication';
 export * from './hooks/updateState';
@@ -9,8 +10,8 @@ export * from './hooks/useForm';
 export * from './hooks/usePagination';
 export * from './hooks/useRequest';
 export * from './hooks/useRetriable';
-export * from './hooks/useSQRequest';
-export * from './hooks/useSSE';
 export * from './hooks/useSerialRequest';
 export * from './hooks/useSerialWatcher';
+export * from './hooks/useSQRequest';
+export * from './hooks/useSSE';
 export * from './hooks/useWatcher';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -31,3 +31,6 @@ export { default as useRetriableRequest } from '@/hooks/useRetriableRequest';
 export { default as useSSE } from '@/hooks/useSSE';
 export { accessAction, actionDelegationMiddleware } from '@/middlewares/actionDelegation';
 export { default as updateState } from '@/updateState';
+
+// helper
+export { statesHookHelper } from '@/util/helper';

--- a/packages/client/typings/clienthook/helper.d.ts
+++ b/packages/client/typings/clienthook/helper.d.ts
@@ -1,0 +1,86 @@
+import { FrameworkReadableState, FrameworkState, GeneralFn, GeneralState } from '@alova/shared';
+import type { AlovaGenerics, EffectRequestParams, ReferingObject, StatesExport, StatesHook } from 'alova';
+import { ExportedComputed, ExportedState } from './general';
+
+type ActualStateTranslator<AG extends AlovaGenerics, StateProxy extends FrameworkReadableState<any, string>> =
+  StateProxy extends FrameworkState<any, string>
+    ? ExportedState<StateProxy['v'], AG['StatesExport']>
+    : ExportedComputed<StateProxy['v'], AG['StatesExport']>;
+type CompletedExposingProvider<AG extends AlovaGenerics, O extends Record<string | number | symbol, any>> = {
+  [K in keyof O]: O[K] extends FrameworkReadableState<any, string>
+    ? ActualStateTranslator<AG, O[K]>
+    : K extends `on${infer eventUnused}`
+      ? (...args: Parameters<O[K]>) => CompletedExposingProvider<AG, O>
+      : O[K];
+};
+
+/**
+ * create simple and unified, framework-independent states creators and handlers.
+ * @param statesHook states hook from `promiseStatesHook` function of alova
+ * @param referingObject refering object exported from `promiseStatesHook` function
+ * @returns simple and unified states creators and handlers
+ */
+// eslint-disable-next-line
+export declare function statesHookHelper<AG extends AlovaGenerics>(
+  statesHook: StatesHook<StatesExport<unknown>>,
+  referingObject?: ReferingObject
+): {
+  create: <Data, Key extends string>(initialValue: Data, key: Key) => FrameworkState<Data, Key>;
+  computed: <Data, Key extends string>(
+    getter: () => Data,
+    depList: (GeneralState | FrameworkReadableState<any, string>)[],
+    key: Key
+  ) => FrameworkReadableState<Data, Key>;
+  effectRequest: (effectRequestParams: EffectRequestParams<any>) => void;
+  ref: <Data>(initialValue: Data) => {
+    current: Data;
+  };
+  memorize: <Callback extends GeneralFn>(fn: Callback) => Callback;
+  watch: (source: (GeneralState | FrameworkReadableState<any, string>)[], callback: () => void) => void;
+  onMounted: (callback: () => void) => void;
+  onUnmounted: (callback: () => void) => void;
+  /**
+   * refering object that sharing some value with this object.
+   */
+  __referingObj: ReferingObject;
+  /**
+   * expose provider for specified use hook.
+   * @param object object that contains state proxy, framework state, operating function and event binder.
+   * @returns provider component.
+   */
+  exposeProvider: <O extends Record<string | number | symbol, any>>(
+    object: O
+  ) => CompletedExposingProvider<
+    AG,
+    O & {
+      __referingObj: ReferingObject;
+      update: (newStates: { [K in keyof O]?: any }) => void;
+      __proxyState: <K extends keyof O>(key: K) => any;
+    }
+  >;
+  /**
+   * transform state proxies to object.
+   * @param states proxy array of framework states
+   * @param filterKey filter key of state proxy
+   * @returns an object that contains the states of target form
+   */
+  objectify: <S extends FrameworkReadableState<any, string>[], Key extends 's' | 'v' | 'e' | undefined = undefined>(
+    states: S,
+    filterKey?: Key
+  ) => {
+    [K in S[number]['k']]: Key extends undefined
+      ? Extract<
+          S[number],
+          {
+            k: K;
+          }
+        >
+      : Extract<
+          S[number],
+          {
+            k: K;
+          }
+        >[NonNullable<Key>];
+  };
+  transformState2Proxy: <Key extends string>(state: GeneralState<any>, key: Key) => FrameworkState<any, Key>;
+};

--- a/packages/client/typings/clienthook/index.d.ts
+++ b/packages/client/typings/clienthook/index.d.ts
@@ -1,4 +1,5 @@
 export * from './general';
+export * from './helper';
 export * from './hooks/actionDelegationMiddleware';
 export * from './hooks/tokenAuthentication';
 export * from './hooks/updateState';
@@ -9,8 +10,8 @@ export * from './hooks/useForm';
 export * from './hooks/usePagination';
 export * from './hooks/useRequest';
 export * from './hooks/useRetriable';
-export * from './hooks/useSQRequest';
-export * from './hooks/useSSE';
 export * from './hooks/useSerialRequest';
 export * from './hooks/useSerialWatcher';
+export * from './hooks/useSQRequest';
+export * from './hooks/useSSE';
 export * from './hooks/useWatcher';


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

none

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

fix that missing export `statesHookHelper` from `alova/client`

**文档 / Docs**

https://alova.js.org/tutorial/advanced/custom/client-strategy#usehook

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

no need.
