### PR TITLE
fix: setting the cached data if found on useRequest initialization

### DIFF
--- a/.changeset/stupid-needles-play.md
+++ b/.changeset/stupid-needles-play.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+fix: setting the cached data if found on useRequest initialization

--- a/packages/client/src/hooks/core/implements/createRequestState.ts
+++ b/packages/client/src/hooks/core/implements/createRequestState.ts
@@ -68,6 +68,7 @@ export default function createRequestState<
   useHookConfig = { ...useHookConfig };
   const { __referingObj: referingObject = { trackedKeys: {}, bindError: falseValue } } = useHookConfig;
   let initialLoading = !!immediate;
+  let cachedResponse: any = undefinedValue;
 
   // When sending a request immediately, you need to determine the initial loading value by whether to force the request and whether there is a cache. This has the following two benefits:
   // 1. Sending the request immediately under react can save one rendering time
@@ -80,7 +81,7 @@ export default function createRequestState<
       const l1CacheResult = (alovaInstance.l1Cache as AlovaGlobalCacheAdapter).get<[any, number]>(
         buildNamespacedCacheKey(alovaInstance.id, getMethodInternalKey(methodInstance))
       );
-      let cachedResponse: any = undefinedValue;
+
       // The cache is only checked synchronously, so it does not take effect on asynchronous l1Cache adapters.
       // It is recommended not to set up the asynchronous l1Cache adapter on the client side
       if (l1CacheResult && !instanceOf(l1CacheResult, PromiseCls)) {
@@ -106,7 +107,7 @@ export default function createRequestState<
   // Put the externally incoming supervised states into the front states collection together
   const { managedStates = {} } = useHookConfig as FrontRequestHookConfig<AG, Args>;
   const managedStatesProxy = mapObject(managedStates, (state, key) => transformState2Proxy(state, key));
-  const data = create((isFn(initialData) ? initialData() : initialData) as AG['Responded'], 'data');
+  const data = create(cachedResponse ?? ((isFn(initialData) ? initialData() : initialData) as AG['Responded']), 'data');
   const loading = create(initialLoading, 'loading');
   const error = create(undefinedValue as Error | undefined, 'error');
   const downloading = create({ ...progress }, 'downloading');

--- a/packages/client/test/vue/core/hooks/useRequest-http.spec.ts
+++ b/packages/client/test/vue/core/hooks/useRequest-http.spec.ts
@@ -29,6 +29,25 @@ describe('use useRequest hook to send GET with vue', () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
+  test('should apply the cache data if is found on the cache on initialization and set `immediate=true`', async () => {
+    const alova = getAlovaInstance(VueHook);
+    const mockFn = vi.fn();
+    const Get = alova.Get('', { cacheFor: 100 * 1000 });
+    await setCache(Get, 'cache-test');
+    const { data: data1 } = useRequest(Get, { initialData: 'test', immediate: true });
+    const { data: data2 } = useRequest(Get, {
+      initialData: () => {
+        mockFn();
+        return 'test';
+      },
+      immediate: true
+    });
+
+    expect(data1.value).toStrictEqual('cache-test');
+    expect(data2.value).toStrictEqual('cache-test');
+    expect(mockFn).toHaveBeenCalledTimes(0);
+  });
+
   test('init and send get request', async () => {
     const alova = getAlovaInstance(VueHook, {
       responseExpect: r => r.json()


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

close #594 

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

prevent screen flash when hit cache in use hooks

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

add tests
