### PR TITLE
fix: cannot send custom params with `send` in `usePagination`, only clone array and plain object in `deepClone`

### DIFF
--- a/.changeset/fresh-eels-smash.md
+++ b/.changeset/fresh-eels-smash.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+fix that cannot receive custom params call send `send` in `usePagination`

--- a/.changeset/ten-foxes-relax.md
+++ b/.changeset/ten-foxes-relax.md
@@ -1,0 +1,5 @@
+---
+'@alova/shared': patch
+---
+
+fix to only clone array and plain object in `deepClone`

--- a/packages/client/test/react/components/Pagination.tsx
+++ b/packages/client/test/react/components/Pagination.tsx
@@ -43,6 +43,7 @@ function Pagination({ getter, paginationConfig = {}, handleExposure = () => {} }
     page,
     pageSize,
     isLastPage,
+    send,
     update,
     insert,
     replace,
@@ -277,6 +278,11 @@ function Pagination({ getter, paginationConfig = {}, handleExposure = () => {} }
         role="clearData"
         onClick={() => update({ data: [] })}>
         btn
+      </button>
+      <button
+        role="customSend"
+        onClick={() => send('a', 1)}>
+        btn1
       </button>
     </div>
   );

--- a/packages/client/test/react/usePagination.spec.tsx
+++ b/packages/client/test/react/usePagination.spec.tsx
@@ -1686,4 +1686,42 @@ describe('react => usePagination', () => {
       expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify([0, 1, 2, 3, 100, 200, 300]));
     });
   });
+
+  test('should receive custom params from function send', async () => {
+    const successFn = vi.fn();
+    const fetchSuccessMockFn = vi.fn();
+    render(
+      <Pagination
+        getter={(page, pageSize) => getter1(page, pageSize)}
+        paginationConfig={{
+          total: (res: any) => res.total,
+          data: (res: any) => res.list,
+          immediate: false
+        }}
+        handleExposure={exposure => {
+          exposure.onSuccess(({ args }) => {
+            successFn(args);
+          });
+          exposure.onFetchSuccess(({ args }) => {
+            fetchSuccessMockFn(args);
+          });
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('page')).toHaveTextContent('1');
+      expect(screen.getByRole('pageSize')).toHaveTextContent('10');
+      expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify([]));
+      expect(screen.getByRole('total')).toHaveTextContent('');
+      expect(screen.getByRole('pageCount')).toHaveTextContent('');
+      expect(screen.getByRole('isLastPage')).toHaveTextContent('true');
+    });
+
+    fireEvent.click(screen.getByRole('customSend'));
+    await waitFor(() => {
+      expect(successFn).toHaveBeenCalledWith(['a', 1, undefined, undefined]);
+      expect(fetchSuccessMockFn).toHaveBeenCalledWith(['a', 1, false]);
+    });
+  });
 });

--- a/packages/client/test/vue/components/pagination.vue
+++ b/packages/client/test/vue/components/pagination.vue
@@ -242,6 +242,11 @@
       ">
       btn1
     </button>
+    <button
+      role="customSend"
+      @click="send('a', 1)">
+      btn1
+    </button>
   </div>
 </template>
 
@@ -257,7 +262,7 @@ type CollapsedAlovaGenerics = Omit<AlovaGenerics, 'StatesExport'> & {
 };
 
 const props = defineProps<{
-  getter: (page: number, pageSize: number) => Method<CollapsedAlovaGenerics>;
+  getter: (page: number, pageSize: number, ...args: any[]) => Method<CollapsedAlovaGenerics>;
   paginationConfig?: PaginationHookConfig<CollapsedAlovaGenerics, unknown[]>;
   handleExposure?: (exposure: ReturnType<typeof usePagination>) => void;
 }>();
@@ -286,6 +291,7 @@ const {
   page,
   pageSize,
   isLastPage,
+  send,
   update,
   insert,
   replace,

--- a/packages/shared/src/function.ts
+++ b/packages/shared/src/function.ts
@@ -408,7 +408,7 @@ export const deepClone = <T>(obj: T): T => {
     return mapItem(obj, deepClone) as T;
   }
 
-  if (isPlainObject(obj)) {
+  if (isPlainObject(obj) && obj.constructor === ObjectCls) {
     const clone = {} as T;
     forEach(objectKeys(obj), key => {
       clone[key as keyof T] = deepClone(obj[key as keyof T]);

--- a/packages/shared/test/function.spec.ts
+++ b/packages/shared/test/function.spec.ts
@@ -663,18 +663,31 @@ describe('shared functions', () => {
     expect(clonedArray[1]).not.toBe(originalArray[1]);
     expect(clonedArray[2]).not.toBe(originalArray[2]);
 
+    class J {}
+
     // objects
     const originalObject = {
       a: 1,
       b: { c: 2 },
       d: [3, 4],
-      e: null
+      e: null,
+      f: undefined,
+      g: () => {},
+      h: Symbol('h'),
+      i: new Date(),
+      j: new J()
     };
     const clonedObject = deepClone(originalObject);
     expect(clonedObject).toStrictEqual(originalObject);
     expect(clonedObject).not.toBe(originalObject);
     expect(clonedObject.b).not.toBe(originalObject.b);
     expect(clonedObject.d).not.toBe(originalObject.d);
+    expect(clonedObject.e).toBeNull();
+    expect(clonedObject.f).toBeUndefined();
+    expect(clonedObject.g).toBe(originalObject.g);
+    expect(clonedObject.h).toBe(originalObject.h);
+    expect(clonedObject.i).toBe(originalObject.i);
+    expect(clonedObject.j).toBe(originalObject.j);
 
     // nested complex structures
     const originalNested = {


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

none

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

1. cannot send custom params with `send` in `usePagination`
2. only clone array and plain object in `deepClone`

**文档 / Docs**

[此次 PR 的文档 / Docs for this PR]

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

all passed
