### PR TITLE
fix: mark option type as optional

### DIFF
--- a/.changeset/good-actors-share.md
+++ b/.changeset/good-actors-share.md
@@ -1,0 +1,5 @@
+---
+'@alova/adapter-xhr': patch
+---
+
+fix: mark option type as optional.

--- a/packages/adapter-xhr/typings/index.d.ts
+++ b/packages/adapter-xhr/typings/index.d.ts
@@ -73,7 +73,7 @@ export interface AlovaXHRAdapterOptions {
 /**
  * XMLHttpRequest request adapter
  */
-export declare function xhrRequestAdapter(options: AlovaXHRAdapterOptions): AlovaXHRAdapter;
+export declare function xhrRequestAdapter(options?: AlovaXHRAdapterOptions): AlovaXHRAdapter;
 
 /**
  * Mock response adapter, which is used in @alova/mock to allow xhr response data to be returned in a format compatible with mock requests.


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [ ] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

mark option type as optional.

**文档 / Docs**

*None*

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

All tests passed.
