### PR TITLE
fix: fix that mismatching cache when items clear in last page

### DIFF
--- a/.changeset/little-baboons-wave.md
+++ b/.changeset/little-baboons-wave.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+fix that mismatching cache when items clear in last page

--- a/packages/client/test/react/usePagination.spec.tsx
+++ b/packages/client/test/react/usePagination.spec.tsx
@@ -552,6 +552,45 @@ describe('react => usePagination', () => {
     });
   });
 
+  test('should turn to previous when datas in last page are removed in preload mode', async () => {
+    const fetchMockFn = vi.fn();
+    const successMockFn = vi.fn();
+    render(
+      <Pagination
+        getter={getter1}
+        paginationConfig={{
+          data: (res: any) => res.list,
+          initialPage: 28,
+          initialPageSize: 11
+        }}
+        handleExposure={(exposure: any) => {
+          exposure.onFetchSuccess(fetchMockFn);
+          exposure.onSuccess(successMockFn);
+        }}
+      />
+    );
+
+    await waitFor(async () => {
+      expect(successMockFn).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify([297, 298, 299]));
+    });
+
+    fetchMockFn.mockClear();
+    fireEvent.click(screen.getByRole('remove0'));
+    fireEvent.click(screen.getByRole('remove0'));
+    fireEvent.click(screen.getByRole('remove0'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify([]));
+    });
+
+    // It will turn to the previous page when the last page is empty
+    await waitFor(() => {
+      expect(screen.getByRole('page')).toHaveTextContent('27');
+      expect(screen.getByRole('response')).toHaveTextContent(JSON.stringify(generateContinuousNumbers(296, 286)));
+    });
+  });
+
   test('paginated data insert item without preload', async () => {
     const fetchMockFn = vi.fn();
     const successMockFn = vi.fn();


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

none

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

fix that mismatching cache when items clear in last page

**文档 / Docs**

none

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

added and all passed
