### PR TITLE
fix: Add optional chaining to headers returned by requestAdapter

### DIFF
--- a/.changeset/famous-gorillas-act.md
+++ b/.changeset/famous-gorillas-act.md
@@ -1,0 +1,5 @@
+---
+'@alova/adapter-axios': patch
+---
+
+to be compatible with falsy data by axios adapter

--- a/packages/adapter-axios/src/requestAdapter.ts
+++ b/packages/adapter-axios/src/requestAdapter.ts
@@ -37,7 +37,7 @@ export default function requestAdapter(options: AdapterCreateOptions = {}) {
 
     return {
       response: () => responsePromise,
-      headers: () => responsePromise.then(res => res.headers as AxiosResponseHeaders),
+      headers: () => responsePromise.then(res => res?.headers as AxiosResponseHeaders),
       abort: () => {
         controller.abort();
       },

--- a/packages/adapter-axios/src/requestAdapter.ts
+++ b/packages/adapter-axios/src/requestAdapter.ts
@@ -1,6 +1,6 @@
-import { noop, undefinedValue } from '@alova/shared';
+import { newInstance, noop, undefinedValue } from '@alova/shared';
 import type { ProgressUpdater } from 'alova';
-import axios, { AxiosResponseHeaders } from 'axios';
+import axios, { AxiosHeaders, AxiosResponseHeaders } from 'axios';
 import { AdapterCreateOptions, AxiosRequestAdapter } from '~/typings';
 
 /**
@@ -37,7 +37,7 @@ export default function requestAdapter(options: AdapterCreateOptions = {}) {
 
     return {
       response: () => responsePromise,
-      headers: () => responsePromise.then(res => res?.headers as AxiosResponseHeaders),
+      headers: () => responsePromise.then(res => (res?.headers || newInstance(AxiosHeaders)) as AxiosResponseHeaders),
       abort: () => {
         controller.abort();
       },


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

close #635 

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

[简要描述所做更改 / Describe the changes briefly]

**文档 / Docs**

[此次 PR 的文档 / Docs for this PR]

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

[描述测试结果 / Describe the test results.]
