### PR TITLE
fix: shouldn't check l2 cache in memory mode when invalidate cache

### DIFF
--- a/.changeset/ninety-eagles-dream.md
+++ b/.changeset/ninety-eagles-dream.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+shouldn't check l2 cache in memory mode when invalidate cache

--- a/packages/alova/test/server/cache.spec.ts
+++ b/packages/alova/test/server/cache.spec.ts
@@ -1,0 +1,39 @@
+import { getAlovaInstance } from '#/utils';
+import { invalidateCache } from '@/index';
+import { Result } from 'root/testUtils';
+
+beforeEach(() => {
+  invalidateCache();
+});
+describe('cache data on server', () => {
+  test("shouldn't check l2 cache in memory mode", async () => {
+    const removeFn = vi.fn();
+    const alova = getAlovaInstance({
+      responseExpect: r => r.json(),
+      l2Cache: {
+        set: () => {},
+        get: () => undefined,
+        remove: removeFn,
+        clear: () => {}
+      }
+    });
+
+    const Get = alova.Get('/unit-test', {
+      transform: ({ data }: Result) => data
+    });
+    await Get;
+    invalidateCache(Get);
+    expect(removeFn).not.toHaveBeenCalled();
+
+    const GetRestore = alova.Get('/unit-test', {
+      cacheFor: {
+        expire: 10000,
+        mode: 'restore'
+      },
+      transform: ({ data }: Result) => data
+    });
+    await GetRestore;
+    invalidateCache(GetRestore);
+    expect(removeFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/alova/typings/index.d.ts
+++ b/packages/alova/typings/index.d.ts
@@ -89,7 +89,7 @@ interface CacheEvent {
 }
 export interface AlovaDefaultCacheAdapter extends AlovaGlobalCacheAdapter {
   /**
-   * the events related to cache operating emitter.
+   * the events related to cache action emitter.
    */
   readonly emitter: EventManager<{ success: CacheEvent; fail: Omit<CacheEvent, 'value'> }>;
 }


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

[Issue ID]

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

remove the checking of l2 cache in memory mode when invalidate cache

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

all passed!