### PR TITLE
fix: fix that l2Cache is not defined in `invalidateCache`

### DIFF
--- a/.changeset/giant-maps-cheat.md
+++ b/.changeset/giant-maps-cheat.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+fix that l2Cache is not defined in `invalidateCache`

--- a/packages/alova/src/alova.ts
+++ b/packages/alova/src/alova.ts
@@ -11,7 +11,7 @@ import {
   StatesHook
 } from '~/typings';
 import Method from './Method';
-import { localStorageAdapter, memoryAdapter } from './defaults/cacheAdapter';
+import { localStorageAdapter, memoryAdapter, placeholderAdapter } from './defaults/cacheAdapter';
 import MethodSnapshotContainer from './storage/MethodSnapshotContainer';
 import myAssert from './utils/myAssert';
 
@@ -59,7 +59,8 @@ export class Alova<AG extends AlovaGenerics> {
     instance.id = (options.id || (idCount += 1)).toString();
     // If storage is not specified, local storage is used by default.
     instance.l1Cache = options.l1Cache || memoryAdapter();
-    instance.l2Cache = options.l2Cache || localStorageAdapter();
+    instance.l2Cache =
+      options.l2Cache || (typeof localStorage !== 'undefined' ? localStorageAdapter() : placeholderAdapter());
 
     // Merge default options
     instance.options = {

--- a/packages/alova/test/server/cache.spec.ts
+++ b/packages/alova/test/server/cache.spec.ts
@@ -36,4 +36,13 @@ describe('cache data on server', () => {
     invalidateCache(GetRestore);
     expect(removeFn).toHaveBeenCalledTimes(1);
   });
+
+  test("shouldn't check l2 cache in memory mode when invalidate all cache", async () => {
+    const alova = getAlovaInstance({
+      responseExpect: r => r.json()
+    });
+
+    expect(alova).not.toBeUndefined();
+    invalidateCache();
+  });
 });

--- a/packages/alova/test/server/createAlova.spec.ts
+++ b/packages/alova/test/server/createAlova.spec.ts
@@ -20,9 +20,6 @@ describe('createAlova', () => {
     expect(() => {
       alova.l2Cache.remove('1');
     }).toThrow(errorTips);
-    expect(() => {
-      alova.l2Cache.clear();
-    }).toThrow(errorTips);
   });
 
   test('cache logger in server', async () => {

--- a/packages/alova/typings/serverhook.d.ts
+++ b/packages/alova/typings/serverhook.d.ts
@@ -1,7 +1,7 @@
 /**
   * @alova/server 1.0.0 (https://alova.js.org)
   * Document https://alova.js.org
-  * Copyright 2024 Scott hu. All Rights Reserved
+  * Copyright 2025 Scott hu. All Rights Reserved
   * Licensed under MIT (git://github.com/alovajs/alova/blob/main/LICENSE)
 */
 


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

none

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

fix that l2Cache is not defined in `invalidateCache`

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

all passed
