### PR TITLE
fix(adapter-mock): fix that cannot receive headers default in mock adapter

### DIFF
--- a/.changeset/angry-impalas-doubt.md
+++ b/.changeset/angry-impalas-doubt.md
@@ -1,0 +1,5 @@
+---
+'@alova/mock': patch
+---
+
+fix that cannot receive headers default in mock adapter

--- a/packages/adapter-mock/src/defaults.ts
+++ b/packages/adapter-mock/src/defaults.ts
@@ -9,13 +9,17 @@ export const defaultMockResponse: MockResponse<any, any, any> = ({
   responseHeaders,
   statusText = 'ok',
   body
-}) => ({
-  response: new Response(isSpecialRequestBody(body) ? body : JSON.stringify(body), {
+}) => {
+  const response = new Response(isSpecialRequestBody(body) ? body : JSON.stringify(body), {
     status,
-    statusText
-  }),
-  headers: new Headers(responseHeaders)
-});
+    statusText,
+    headers: responseHeaders
+  });
+  return {
+    response,
+    headers: response.headers
+  };
+};
 
 /**
  * Return the error message itself


### PR DESCRIPTION


<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->


<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

fix that cannot receive headers default in mock adapter

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

all passed
