### PR TITLE
fix: `on` method in useSSE cannot be chained #670

### DIFF
--- a/.changeset/long-llamas-sell.md
+++ b/.changeset/long-llamas-sell.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+fix: fix the issue where the on method in useSSE cannot be chained

--- a/packages/alova/typings/clienthook/hooks/useSSE.d.ts
+++ b/packages/alova/typings/clienthook/hooks/useSSE.d.ts
@@ -24,10 +24,6 @@ export type SSEOnMessageTrigger<Data, AG extends AlovaGenerics, Args extends any
 export type SSEOnErrorTrigger<AG extends AlovaGenerics, Args extends any[] = any[]> = (
   event: AlovaSSEErrorEvent<AG, Args>
 ) => void;
-export type SSEOn<AG extends AlovaGenerics, Args extends any[] = any[]> = <Data = any>(
-  eventName: string,
-  handler: (event: AlovaSSEMessageEvent<Data, AG, Args>) => void
-) => () => void;
 
 /**
  *  useSSE() configuration item
@@ -66,9 +62,9 @@ export interface SSEHookConfig {
 /**
  * useSSE() return type
  */
-export interface SSEExposure<AG extends AlovaGenerics, Data, Args extends any[] = any[]> {
+export interface SSEExposure<AG extends AlovaGenerics, Args extends any[] = any[]> {
   readyState: ExportedState<SSEHookReadyState, AG['StatesExport']>;
-  data: ExportedState<Data | undefined, AG['StatesExport']>;
+  data: ExportedState<AG['Responded'], AG['StatesExport']>;
   eventSource: ExportedState<EventSource | undefined, AG['StatesExport']>;
   /**
    * Make the request manually. This method is automatically triggered when using `immediate: true`
@@ -91,7 +87,7 @@ export interface SSEExposure<AG extends AlovaGenerics, Data, Args extends any[] 
    * @param callback callback function
    * @returns Unregister function
    */
-  onMessage<T = Data>(callback: SSEOnMessageTrigger<T, AG, Args>): this;
+  onMessage<T = AG['Responded']>(callback: SSEOnMessageTrigger<T, AG, Args>): this;
 
   /**
    * Register the callback function for EventSource error
@@ -104,7 +100,7 @@ export interface SSEExposure<AG extends AlovaGenerics, Data, Args extends any[] 
    * @param eventName Event name, default exists `open` | `error` | `message`
    * @param handler event handler
    */
-  on: SSEOn<AG>;
+  on<T = AG['Responded']>(eventName: string, handler: (event: AlovaSSEMessageEvent<T, AG, Args>) => void): this;
 }
 
 /**
@@ -116,7 +112,7 @@ export interface SSEExposure<AG extends AlovaGenerics, Data, Args extends any[] 
  * @param config Configuration parameters
  * @return useSSE related data and operation functions
  */
-export declare function useSSE<Data = any, AG extends AlovaGenerics = AlovaGenerics, Args extends any[] = any[]>(
+export declare function useSSE<AG extends AlovaGenerics = AlovaGenerics, Args extends any[] = any[]>(
   handler: Method<AG> | AlovaMethodHandler<AG, Args>,
   config?: SSEHookConfig
-): SSEExposure<AG, Data, Args>;
+): SSEExposure<AG, Args>;

--- a/packages/client/src/event.ts
+++ b/packages/client/src/event.ts
@@ -103,7 +103,7 @@ export class AlovaSSEErrorEvent<AG extends AlovaGenerics, Args extends any[] = a
   }
 }
 
-export class AlovaSSEMessageEvent<AG extends AlovaGenerics, Data, Args extends any[] = any[]> extends AlovaSSEEvent<
+export class AlovaSSEMessageEvent<Data, AG extends AlovaGenerics, Args extends any[] = any[]> extends AlovaSSEEvent<
   AG,
   Args
 > {

--- a/packages/client/src/hooks/useSSE.ts
+++ b/packages/client/src/hooks/useSSE.ts
@@ -28,7 +28,7 @@ import {
   hitCacheBySource,
   promiseStatesHook
 } from 'alova';
-import { AlovaMethodHandler, SSEHookConfig, SSEOn } from '~/typings/clienthook';
+import { AlovaMethodHandler, SSEHookConfig } from '~/typings/clienthook';
 
 const SSEOpenEventKey = Symbol('SSEOpen');
 const SSEMessageEventKey = Symbol('SSEMessage');
@@ -41,11 +41,11 @@ export const enum SSEHookReadyState {
 
 export type SSEEvents<Data, AG extends AlovaGenerics, Args extends any[]> = {
   [SSEOpenEventKey]: AlovaSSEEvent<AG, Args>;
-  [SSEMessageEventKey]: AlovaSSEMessageEvent<AG, Data, Args>;
+  [SSEMessageEventKey]: AlovaSSEMessageEvent<Data, AG, Args>;
   [SSEErrorEventKey]: AlovaSSEErrorEvent<AG, Args>;
 };
 
-type AnySSEEventType<Data, AG extends AlovaGenerics, Args extends any[]> = AlovaSSEMessageEvent<AG, Data, Args> &
+type AnySSEEventType<Data, AG extends AlovaGenerics, Args extends any[]> = AlovaSSEMessageEvent<Data, AG, Args> &
   AlovaSSEErrorEvent<AG, Args> &
   AlovaSSEEvent<AG, Args>;
 
@@ -92,7 +92,7 @@ export default <Data = any, AG extends AlovaGenerics = AlovaGenerics, Args exten
   const onOpen = (handler: (event: AlovaSSEEvent<AG, Args>) => void) => {
     eventManager.on(SSEOpenEventKey, handler);
   };
-  const onMessage = (handler: <Data>(event: AlovaSSEMessageEvent<AG, Data, Args>) => void) => {
+  const onMessage = (handler: <Data>(event: AlovaSSEMessageEvent<Data, AG, Args>) => void) => {
     eventManager.on(SSEMessageEventKey, handler);
   };
   const onError = (handler: (event: AlovaSSEErrorEvent<AG, Args>) => void) => {
@@ -198,7 +198,10 @@ export default <Data = any, AG extends AlovaGenerics = AlovaGenerics, Args exten
 
   // * MARK: Event handling of EventSource
 
-  const onCustomEvent: SSEOn<AG, Args> = (eventName, callbackHandler) => {
+  const onCustomEvent = <T = AG['Responded']>(
+    eventName: string,
+    callbackHandler: (event: AlovaSSEMessageEvent<T, AG, Args>) => void
+  ) => {
     const currentMap = customEventMap.current;
     if (!currentMap.has(eventName)) {
       const useCallbackObject = useCallback<(event: AlovaSSEEvent<AG, Args>) => void>(callbacks => {

--- a/packages/client/test/type/exposure.spec-d.ts
+++ b/packages/client/test/type/exposure.spec-d.ts
@@ -1,7 +1,8 @@
 import { createAlova } from 'alova';
-import { usePagination, useRequest } from 'alova/client';
+import { usePagination, useRequest, useSSE } from 'alova/client';
 import vueHook from 'alova/vue';
 import { Ref } from 'vue';
+import { AlovaSSEErrorEvent, AlovaSSEEvent, AlovaSSEMessageEvent } from '../../typings/clienthook/hooks/useSSE';
 
 const emptyRequestAdapter = () => ({
   response: () => Promise.resolve({}),
@@ -49,6 +50,31 @@ describe('hook exposure', () => {
         .onSuccess(() => {})
         .onSuccess(() => {})
         .onSuccess(() => {})
+    );
+  });
+
+  test('useSSE', () => {
+    const sseExposure = useSSE(Getter<number>, {
+      immediate: false
+    });
+    type SSEExposure = typeof sseExposure;
+
+    assertType<Ref<number>>(sseExposure.data);
+    assertType<Ref<EventSource | undefined>>(sseExposure.eventSource);
+    assertType<Ref<0 | 1 | 2>>(sseExposure.readyState);
+
+    // 测试事件处理函数
+    assertType<SSEExposure>(sseExposure.onOpen((_event: AlovaSSEEvent<any>) => {}));
+    assertType<SSEExposure>(sseExposure.onMessage((_event: AlovaSSEMessageEvent<number, any>) => {}));
+    assertType<SSEExposure>(sseExposure.onError((_event: AlovaSSEErrorEvent<any>) => {}));
+
+    // 测试链式调用
+    assertType<SSEExposure>(
+      sseExposure
+        .onOpen(() => {})
+        .onMessage(() => {})
+        .onError(() => {})
+        .on('customEvent', () => {})
     );
   });
 });

--- a/packages/client/test/vue/components/use-sse.vue
+++ b/packages/client/test/vue/components/use-sse.vue
@@ -45,22 +45,22 @@ const onErrorCounter = ref(0);
 const onMessageCounter = ref(0);
 
 const poster = (data: any) => alovaInst.Get(props.path, data);
-const { onMessage, onOpen, onError, data, readyState, send, close } = useSSE(poster, {
+const exposure = useSSE(poster, {
   initialData: props.initialData,
   immediate: props.immediate
 });
+const { data, readyState, send, close } = exposure;
 
-onMessage(e => {
-  onMessageCounter.value += 1;
-});
-
-onOpen(() => {
-  onOpenCounter.value += 1;
-});
-
-onError(() => {
-  onErrorCounter.value += 1;
-});
+exposure
+  .onMessage(e => {
+    onMessageCounter.value += 1;
+  })
+  .onOpen(() => {
+    onOpenCounter.value += 1;
+  })
+  .onError(() => {
+    onErrorCounter.value += 1;
+  });
 
 const getStatusText = computed(() => {
   if (readyState.value === 1 /** Sse hook ready state.open */) {

--- a/packages/client/typings/clienthook/hooks/useSSE.d.ts
+++ b/packages/client/typings/clienthook/hooks/useSSE.d.ts
@@ -24,10 +24,6 @@ export type SSEOnMessageTrigger<Data, AG extends AlovaGenerics, Args extends any
 export type SSEOnErrorTrigger<AG extends AlovaGenerics, Args extends any[] = any[]> = (
   event: AlovaSSEErrorEvent<AG, Args>
 ) => void;
-export type SSEOn<AG extends AlovaGenerics, Args extends any[] = any[]> = <Data = any>(
-  eventName: string,
-  handler: (event: AlovaSSEMessageEvent<Data, AG, Args>) => void
-) => () => void;
 
 /**
  *  useSSE() configuration item
@@ -66,9 +62,9 @@ export interface SSEHookConfig {
 /**
  * useSSE() return type
  */
-export interface SSEExposure<AG extends AlovaGenerics, Data, Args extends any[] = any[]> {
+export interface SSEExposure<AG extends AlovaGenerics, Args extends any[] = any[]> {
   readyState: ExportedState<SSEHookReadyState, AG['StatesExport']>;
-  data: ExportedState<Data | undefined, AG['StatesExport']>;
+  data: ExportedState<AG['Responded'], AG['StatesExport']>;
   eventSource: ExportedState<EventSource | undefined, AG['StatesExport']>;
   /**
    * Make the request manually. This method is automatically triggered when using `immediate: true`
@@ -91,7 +87,7 @@ export interface SSEExposure<AG extends AlovaGenerics, Data, Args extends any[] 
    * @param callback callback function
    * @returns Unregister function
    */
-  onMessage<T = Data>(callback: SSEOnMessageTrigger<T, AG, Args>): this;
+  onMessage<T = AG['Responded']>(callback: SSEOnMessageTrigger<T, AG, Args>): this;
 
   /**
    * Register the callback function for EventSource error
@@ -104,7 +100,7 @@ export interface SSEExposure<AG extends AlovaGenerics, Data, Args extends any[] 
    * @param eventName Event name, default exists `open` | `error` | `message`
    * @param handler event handler
    */
-  on: SSEOn<AG>;
+  on<T = AG['Responded']>(eventName: string, handler: (event: AlovaSSEMessageEvent<T, AG, Args>) => void): this;
 }
 
 /**
@@ -116,7 +112,7 @@ export interface SSEExposure<AG extends AlovaGenerics, Data, Args extends any[] 
  * @param config Configuration parameters
  * @return useSSE related data and operation functions
  */
-export declare function useSSE<Data = any, AG extends AlovaGenerics = AlovaGenerics, Args extends any[] = any[]>(
+export declare function useSSE<AG extends AlovaGenerics = AlovaGenerics, Args extends any[] = any[]>(
   handler: Method<AG> | AlovaMethodHandler<AG, Args>,
   config?: SSEHookConfig
-): SSEExposure<AG, Data, Args>;
+): SSEExposure<AG, Args>;


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

#670 

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

- fix the issue where the on method in useSSE cannot be chained
- remove method type `SSEOn`
- remove generic type `Data` to make the data type consistent with AG Responded

**文档 / Docs**

*None*

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

All tests have passed
