### PR TITLE
fix(types): correct type declaration of `accessAction()` #673

### DIFF
--- a/.changeset/lemon-waves-leave.md
+++ b/.changeset/lemon-waves-leave.md
@@ -1,0 +1,8 @@
+---
+'alova': patch
+---
+
+fix(types): correct type declaration of `accessAction()`
+fix(test): ensure vitest runs typecheck correctly
+
+- correct vitest config to enable typecheck for specific test file

--- a/packages/alova/typings/clienthook/hooks/actionDelegationMiddleware.d.ts
+++ b/packages/alova/typings/clienthook/hooks/actionDelegationMiddleware.d.ts
@@ -32,5 +32,6 @@ export declare function actionDelegationMiddleware<
  */
 export declare function accessAction(
   id: string | number | symbol | RegExp,
-  onMatch: (matchedSubscriber: Record<string, any>, index: number) => void
+  onMatch: (matchedSubscriber: Record<string, any>, index: number) => void,
+  silent?: boolean
 ): void;

--- a/packages/client/test/type/actionDelegation.spec-d.ts
+++ b/packages/client/test/type/actionDelegation.spec-d.ts
@@ -1,0 +1,24 @@
+import { accessAction } from 'alova/client';
+
+describe('actionDelegation types', () => {
+  test('accessAction parameters', () => {
+    // Define common types
+    type MatchCallback = (matchedSubscriber: Record<string, any>, index: number) => void;
+    type IdType = string | number | symbol | RegExp;
+
+    // id parameter type
+    expectTypeOf(accessAction).parameter(0).toMatchTypeOf<IdType>();
+    // @ts-expect-error
+    expectTypeOf(accessAction).parameter(0).toMatchTypeOf<{ name: string }>();
+
+    // onMatch parameter type
+    expectTypeOf(accessAction).parameter(1).toMatchTypeOf<MatchCallback>();
+    // @ts-expect-error
+    expectTypeOf(accessAction).parameter(1).toMatchTypeOf<() => void>();
+
+    // silent parameter type
+    expectTypeOf(accessAction).parameter(2).toMatchTypeOf<boolean | undefined>();
+    // @ts-expect-error
+    expectTypeOf(accessAction).parameter(2).toMatchTypeOf<string>();
+  });
+});

--- a/packages/client/typings/clienthook/hooks/actionDelegationMiddleware.d.ts
+++ b/packages/client/typings/clienthook/hooks/actionDelegationMiddleware.d.ts
@@ -32,5 +32,6 @@ export declare function actionDelegationMiddleware<
  */
 export declare function accessAction(
   id: string | number | symbol | RegExp,
-  onMatch: (matchedSubscriber: Record<string, any>, index: number) => void
+  onMatch: (matchedSubscriber: Record<string, any>, index: number) => void,
+  silent?: boolean
 ): void;

--- a/packages/client/vitest.config.ssr.ts
+++ b/packages/client/vitest.config.ssr.ts
@@ -20,7 +20,10 @@ export default mergeConfig(
     test: {
       name: '[SSR]client',
       environment: 'node',
-      include: ['test/ssr/**/*.{test,spec}.ts(x)?']
+      include: ['test/ssr/**/*.{test,spec}.ts(x)?'],
+      typecheck: {
+        enabled: false
+      }
     }
   })
 );

--- a/vitest.config.base.ts
+++ b/vitest.config.base.ts
@@ -3,7 +3,7 @@ import { defineProject } from 'vitest/config';
 
 export default defineProject({
   test: {
-    include: ['**/*.{test,test-d,spec,spec-d}.?(c|m)[jt]s?(x)'],
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     alias: {
       '~': process.cwd(),
       '#': resolve(process.cwd(), 'test'),
@@ -12,6 +12,11 @@ export default defineProject({
     },
     environment: 'jsdom',
     setupFiles: [resolve(__dirname, 'internal/vitest.setup.ts')],
-    globals: true
+    globals: true,
+    typecheck: {
+      include: ['**/*.{test-d,spec-d}.ts?(x)'],
+      enabled: true,
+      ignoreSourceErrors: true
+    }
   }
 });


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

#673 

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

- correct type declaration of `accessAction()`
- update vitest config to ensure `*.spec-d.ts` tests runs correctly

**文档 / Docs**

*None*

**测试 / Testing**

All tests have passed.