### PR TITLE
Fix/nuxthook ssefetch

### DIFF
--- a/.changeset/rich-glasses-hang.md
+++ b/.changeset/rich-glasses-hang.md
@@ -1,0 +1,5 @@
+---
+'@alova/shared': patch
+---
+
+fix that the `isSSR` is `true` in alipay miniprogram

--- a/.changeset/slimy-oranges-battle.md
+++ b/.changeset/slimy-oranges-battle.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+trigger request in usehook calling without `await` in nuxt environment

--- a/.changeset/tame-points-dress.md
+++ b/.changeset/tame-points-dress.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+compatible with `Event` which is not in browser

--- a/.changeset/tiny-shirts-fly.md
+++ b/.changeset/tiny-shirts-fly.md
@@ -1,0 +1,5 @@
+---
+'@alova/shared': patch
+---
+
+fix that `this.$dhy` is not a function in miniprogram of alipay

--- a/packages/alova/typings/clienthook/hooks/useUploader.d.ts
+++ b/packages/alova/typings/clienthook/hooks/useUploader.d.ts
@@ -171,10 +171,8 @@ export interface UploadExposure<AG extends AlovaGenerics, Args extends any[] = a
    * @param options - file append options.
    * @returns The number of successfully appended files. Append may fail due to quantity or format restrictions.
    */
-  appendFiles: (
-    file?: AlovaRawFile | AlovaRawFile[] | FileAppendOptions,
-    options?: FileAppendOptions
-  ) => Promise<number>;
+  appendFiles(file?: AlovaRawFile | AlovaRawFile[], options?: FileAppendOptions): Promise<number>;
+  appendFiles(options?: FileAppendOptions): Promise<number>;
   /**
    * Removes files from the upload list. if no parameters are given, it will remove all files.
    * @param positions - The file items or indexes in `fileList`.

--- a/packages/alova/typings/index.d.ts
+++ b/packages/alova/typings/index.d.ts
@@ -239,6 +239,10 @@ export interface ReferingObject {
    * has been bound error event
    */
   bindError: boolean;
+  /**
+   * is initial request
+   */
+  initialRequest: boolean;
   [key: string]: any;
 }
 export type StatesExportHelper<I extends StatesExport<any>> = I;

--- a/packages/client/src/hooks/sse/event.ts
+++ b/packages/client/src/hooks/sse/event.ts
@@ -1,5 +1,5 @@
 import { AlovaEventBase } from '@/event';
-import { trueValue } from '@alova/shared';
+import { falseValue, nullValue, trueValue } from '@alova/shared';
 import { AlovaGenerics } from 'alova';
 import type EventSourceFetch from './EventSourceFetch';
 
@@ -16,7 +16,73 @@ interface EventSourceFetchEventInit {
   error?: Error;
 }
 
-export class EventSourceFetchEvent extends Event {
+interface BaseEventInit {
+  bubbles?: boolean;
+  cancelable?: boolean;
+  composed?: boolean;
+}
+class BaseEvent {
+  readonly type: string;
+  readonly bubbles: boolean;
+  readonly cancelable: boolean;
+  readonly composed: boolean;
+  readonly timeStamp: number;
+
+  // Event standard properties
+  cancelBubble: boolean = falseValue;
+  currentTarget: EventTarget | null = nullValue;
+  defaultPrevented: boolean = falseValue;
+  eventPhase: number = 0;
+  isTrusted: boolean = falseValue;
+  returnValue: boolean = trueValue;
+  srcElement: EventTarget | null = nullValue;
+  target: EventTarget | null = nullValue;
+
+  // Event standard constants
+  static readonly NONE = 0;
+  static readonly CAPTURING_PHASE = 1;
+  static readonly AT_TARGET = 2;
+  static readonly BUBBLING_PHASE = 3;
+
+  readonly NONE = 0;
+  readonly CAPTURING_PHASE = 1;
+  readonly AT_TARGET = 2;
+  readonly BUBBLING_PHASE = 3;
+
+  constructor(type: string, eventInitDict: BaseEventInit = {}) {
+    this.type = type;
+    this.bubbles = eventInitDict.bubbles ?? false;
+    this.cancelable = eventInitDict.cancelable ?? false;
+    this.composed = eventInitDict.composed ?? false;
+    this.timeStamp = Date.now();
+  }
+
+  // Event 标准方法
+  preventDefault(): void {
+    if (this.cancelable) {
+      this.defaultPrevented = true;
+    }
+  }
+
+  stopImmediatePropagation(): void {}
+
+  stopPropagation(): void {
+    this.cancelBubble = true;
+  }
+
+  composedPath(): EventTarget[] {
+    return [];
+  }
+
+  initEvent(type: string, bubbles?: boolean, cancelable?: boolean): void {
+    type;
+    bubbles;
+    cancelable;
+  }
+}
+
+const EventConstructor = typeof Event !== 'undefined' ? Event : BaseEvent;
+export class EventSourceFetchEvent extends EventConstructor {
   /** Event data */
   readonly data: string;
   /** Last event ID */

--- a/packages/client/src/util/helper.ts
+++ b/packages/client/src/util/helper.ts
@@ -155,7 +155,12 @@ type CompletedExposingProvider<AG extends AlovaGenerics, O extends Record<string
  */
 export function statesHookHelper<AG extends AlovaGenerics>(
   statesHook: StatesHook<StatesExport<unknown>>,
-  referingObject: ReferingObject = { trackedKeys: {}, bindError: falseValue, ...injectReferingObject() }
+  referingObject: ReferingObject = {
+    trackedKeys: {},
+    bindError: falseValue,
+    initialRequest: falseValue,
+    ...injectReferingObject()
+  }
 ) {
   const ref = <Data>(initialValue: Data) => (statesHook.ref ? statesHook.ref(initialValue) : { current: initialValue });
   referingObject = ref(referingObject).current;
@@ -322,13 +327,13 @@ export function statesHookHelper<AG extends AlovaGenerics>(
 
         /**
          * send and wait for responding with `await`
-         * this is always used in `nuxt3`
+         * this is always used in `nuxt3` and suspense in vue3
          * @example
          * ```js
          * const { loading, data, error } = await useRequest(...);
          * ```
          */
-        then(onfulfilled: (result: any) => void) {
+        then(onfulfilled: (result: any) => void, onrejected: (reason: any) => void) {
           // open all the states to track.
           forEach(stateKeys, key => {
             referingObject.trackedKeys[key] = trueValue;
@@ -340,7 +345,7 @@ export function statesHookHelper<AG extends AlovaGenerics>(
             // eslint-disable-next-line
             onfulfilled(completedProvider);
           };
-          isFn(providerThen) ? providerThen(handleFullfilled) : handleFullfilled();
+          isFn(providerThen) ? providerThen(handleFullfilled, onrejected) : handleFullfilled();
         }
       };
 

--- a/packages/client/test/nuxt/stateshook-common.spec.ts
+++ b/packages/client/test/nuxt/stateshook-common.spec.ts
@@ -18,7 +18,8 @@ vi.mock('vue', async importOriginal => {
 });
 const referingObject: ReferingObject = {
   trackedKeys: {},
-  bindError: false
+  bindError: false,
+  initialRequest: false
 };
 describe('nuxt adapter - common', async () => {
   let mockNuxtApp: NuxtApp;

--- a/packages/client/test/nuxt/stateshook-server.spec.ts
+++ b/packages/client/test/nuxt/stateshook-server.spec.ts
@@ -16,7 +16,8 @@ vi.mock('vue', async importOriginal => {
 });
 const referingObject: ReferingObject = {
   trackedKeys: {},
-  bindError: false
+  bindError: false,
+  initialRequest: false
 };
 const importNuxtHook = async () => {
   Object.defineProperty(global, 'window', {
@@ -106,7 +107,7 @@ describe('nuxt.ts adapter', async () => {
     expect(mockNuxtApp.payload.alova_testKey2_2).toStrictEqual(['mock', '123']);
   });
 
-  test("shouldn't immediately call handler in effectRequest even when immediate is true", () => {
+  test("shouldn't immediately call handler in effectRequest even if immediate is true", () => {
     const adapter = nuxtHookServer(mockConfig);
     const handler = vi.fn();
     const removeStates = vi.fn();
@@ -119,9 +120,14 @@ describe('nuxt.ts adapter', async () => {
         watchingStates: [],
         frontStates: {}
       },
-      referingObject
+      {
+        ...referingObject,
+        initialRequest: true
+      }
     );
     expect(handler).toHaveBeenCalled();
-    expect(mockNuxtApp.hooks.hook).toHaveBeenCalledTimes(1);
+    expect(mockNuxtApp.hooks.hook).toHaveBeenLastCalledWith('app:rendered', expect.any(Function));
+    mockNuxtApp.hooks.callHook('app:rendered', '' as any);
+    expect(mockNuxtApp.payload.alova_initialRequest_1).toBeTruthy();
   });
 });

--- a/packages/client/test/solid/statesHook.solid.spec.tsx
+++ b/packages/client/test/solid/statesHook.solid.spec.tsx
@@ -9,7 +9,8 @@ import { createRoot, createSignal } from 'solid-js';
 
 const referingObject: ReferingObject = {
   trackedKeys: {},
-  bindError: false
+  bindError: false,
+  initialRequest: false
 };
 const alova = getAlovaInstance(Solidhook, {
   responseExpect: r => r.json()

--- a/packages/client/test/ssr/hooks-vue.spec.ts
+++ b/packages/client/test/ssr/hooks-vue.spec.ts
@@ -53,10 +53,7 @@ describe('[vue]use hooks in SSR', () => {
     expect(abort).toBeInstanceOf(Function);
     expect(send).toBeInstanceOf(Function);
 
-    const { loading: loading2, data: data2, error: error2 } = await useRequest(alova.Get<Result>('/unit-test-error'));
-    expect(loading2.value).toBeFalsy();
-    expect(data2.value).toBeUndefined();
-    expect(error2.value?.message).toMatch('Failed to fetch');
+    await expect(useRequest(alova.Get<Result>('/unit-test-error'))).rejects.toThrowError('Failed to fetch');
   });
 
   test('should `useWatcher` receive all exposures in promise after request', async () => {
@@ -82,16 +79,11 @@ describe('[vue]use hooks in SSR', () => {
     expect(data.value.data.path).toBe('/unit-test');
     expect(error.value).toBeUndefined();
 
-    const {
-      loading: loading2,
-      data: data2,
-      error: error2
-    } = await useWatcher(alova.Get<Result>('/unit-test-error'), [ref(1)], {
-      immediate: true
-    });
-    expect(loading2.value).toBeFalsy();
-    expect(data2.value).toBeUndefined();
-    expect(error2.value?.message).toMatch('Failed to fetch');
+    await expect(
+      useWatcher(alova.Get<Result>('/unit-test-error'), [ref(1)], {
+        immediate: true
+      })
+    ).rejects.toThrowError('Failed to fetch');
   });
 
   test("shouldn't request when `immediate` set to false", async () => {

--- a/packages/client/tsconfig.vitest-temp.json
+++ b/packages/client/tsconfig.vitest-temp.json
@@ -1,0 +1,47 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "resolveJsonModule": true,
+    "target": "es2018",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "newLine": "LF",
+    "noImplicitAny": true,
+    "noEmitOnError": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "strictPropertyInitialization": false,
+    "noFallthroughCasesInSwitch": false,
+    "skipLibCheck": false,
+    "allowJs": true,
+    "skipDefaultLibCheck": false,
+    "isolatedModules": true,
+    "inlineSourceMap": false,
+    "importHelpers": true,
+    "removeComments": false,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "paths": {
+      "@/*": ["src/*"],
+      "~/*": ["./*"],
+      "#/*": ["test/*"],
+      "root/*": ["../../internal/*"]
+    },
+    "emitDeclarationOnly": false,
+    "incremental": true,
+    "tsBuildInfoFile": "/Users/huzhen/Documents/JOU/codes/jslibs/alova/node_modules/.pnpm/vitest@2.1.4_@types+node@20.17.3_jsdom@25.0.1_msw@2.3.5_typescript@5.6.3__terser@5.36.0/node_modules/vitest/dist/chunks/tsconfig.tmp.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.js",
+    "typings/**/*.d.ts",
+    "test/**/*.ts",
+    "test/**/*.tsx",
+    "test/**/*.vue",
+    "test/**/*.svelte"
+  ]
+}

--- a/packages/shared/src/FrameworkState.ts
+++ b/packages/shared/src/FrameworkState.ts
@@ -47,6 +47,6 @@ export class FrameworkState<Data, Key extends string> extends FrameworkReadableS
   }
 
   get v() {
-    return super.v;
+    return this.$dhy(this.s);
   }
 }

--- a/packages/shared/src/vars.ts
+++ b/packages/shared/src/vars.ts
@@ -53,11 +53,9 @@ export const valueObject = <T>(value: T, writable = falseValue) => ({ value, wri
 export const defineProperty = (o: object, key: string | symbol, value: any, isDescriptor = falseValue) =>
   ObjectCls.defineProperty(o, key, isDescriptor ? value : valueObject(value, falseValue));
 // Whether it is running on the server side, node and bun are judged by process, and deno is judged by Deno.
-// Some frameworks (such as Alipay and uniapp) will inject the process object as a global variable.
-// Therefore, the process.cwd function unique to the server is used as the basis for judgment.
+// Some frameworks (such as Alipay and uniapp) will inject the process object as a global variable which `browser` is true
 export const isSSR =
-  typeof window === undefStr &&
-  (typeof process !== undefStr ? typeof (process as any).cwd === 'function' : typeof Deno !== undefStr);
+  typeof window === undefStr && (typeof process !== undefStr ? !(process as any).browser : typeof Deno !== undefStr);
 
 /** cache mode */
 // only cache in memory, it's default option

--- a/packages/shared/test/isSSR.spec.ts
+++ b/packages/shared/test/isSSR.spec.ts
@@ -4,9 +4,7 @@ const undefStr = 'undefined';
 const MockGlobal: any = {};
 const isSSR = () =>
   typeof MockGlobal.window === undefStr &&
-  (typeof MockGlobal.process !== undefStr
-    ? typeof MockGlobal.process.cwd === 'function'
-    : typeof MockGlobal.Deno !== undefStr);
+  (typeof MockGlobal.process !== undefStr ? !MockGlobal.process.browser : typeof MockGlobal.Deno !== undefStr);
 
 const setGlobalWindow = (window: any) => {
   MockGlobal.window = window;
@@ -58,14 +56,14 @@ describe('isSSR', () => {
 
   it('should return false in Alipay Mini Program environment', () => {
     // Alipay Mini Program: process is {browser: true}, Deno is undefined
-    setGlobalProcess({ browser: true });
+    setGlobalProcess({ browser: true, cwd: () => '/' });
     setGlobalDeno(undefined);
     expect(isSSR()).toBeFalsy();
   });
 
   it('should return false in DingTalk Mini Program environment', () => {
     // DingTalk Mini Program: process is {browser: true}, Deno is undefined
-    setGlobalProcess({ browser: true });
+    setGlobalProcess({ browser: true, cwd: () => '/' });
     setGlobalDeno(undefined);
     expect(isSSR()).toBeFalsy();
   });


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

close #710, #721

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

1. 修复nuxt中不使用`await`，在客户端不请求的问题
2. 修复nuxt中在服务端请求错误不抛出错误的问题
3. 修复useSSE中非浏览器环境访问不到`Event`的问题
4. 修复支付宝环境下`isSSR`为true的问题
5. 修复支付宝环境下`this.$dhy is not a function`的问题

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

全部通过
