### PR TITLE
Update globalfetch.d.cts

### DIFF
--- a/typings/globalfetch.d.cts
+++ b/typings/globalfetch.d.cts
@@ -1,6 +1,6 @@
 import { AlovaRequestAdapter } from '.';
 
-declare namespace FetchTypes {
+declare namespace GlobalFetch {
   type FetchRequestInit = Omit<RequestInit, 'body' | 'headers' | 'method'>;
 
   /**
@@ -9,5 +9,5 @@ declare namespace FetchTypes {
   type GlobalFetchRequestAdapter = AlovaRequestAdapter<any, any, FetchRequestInit, Response, Headers>;
 }
 
-declare function GlobalFetch(): FetchTypes.GlobalFetchRequestAdapter;
-export = FetchTypes;
+declare function GlobalFetch(): GlobalFetch.GlobalFetchRequestAdapter;
+export = GlobalFetch;


### PR DESCRIPTION
当我在commonjs的情况下使用`GlobalFetch()`并没有类型推断因为直接导出了名字空间并没有导出GlobalFetch函数类型声明

<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

无相关Issue

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**
<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [x] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

修改名字空间类型名称为GlobalFech并且和GlobalFech函数同名，让导出的既是名字空间又是函数方法。

**文档 / Docs**
none

