### PR TITLE
fix: detech ssr in `onUnmount` to prevent error in svelitekit

### DIFF
--- a/.changeset/smooth-dryers-carry.md
+++ b/.changeset/smooth-dryers-carry.md
@@ -1,0 +1,5 @@
+---
+'alova': patch
+---
+
+detech ssr in `onUnmount` to prevent error in svelitekit

--- a/packages/client/src/statesHook/svelte.ts
+++ b/packages/client/src/statesHook/svelte.ts
@@ -50,6 +50,6 @@ export default {
     onMount(callback);
   },
   onUnmounted: callback => {
-    onDestroy(callback);
+    !isSSR && onDestroy(callback);
   }
 } as StatesHook<SvelteHookExportType<unknown>>;


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

none

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**

fix: detech ssr in `onUnmount` to prevent error in svelitekit
