### PR TITLE
修复：创建 method 实例时传入fetch的参数signal，未生效  #843

### DIFF
--- a/packages/alova/src/predefine/adapterFetch.ts
+++ b/packages/alova/src/predefine/adapterFetch.ts
@@ -30,6 +30,44 @@ export default function adapterFetch(
     const isContentTypeSet = /content-type/i.test(ObjectCls.keys(headers).join());
     const isFormData = data && data.toString() === '[object FormData]';
 
+    let cleaned = false;
+    let abortTimer: NodeJS.Timeout | number;
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
+      if (abortTimer !== undefined) clearTimeoutTimer(abortTimer);
+      if (externalAbortHandler) {
+        externalSignal!.removeEventListener('abort', externalAbortHandler);
+        externalAbortHandler = null;
+      }
+    };
+
+    const doAbort = () => {
+      ctrl.abort();
+      cleanup();
+    };
+
+    // If the interruption time is set, the request will be interrupted after the specified time.
+    let isTimeout = falseValue;
+    if (timeout > 0) {
+      abortTimer = setTimeoutFn(() => {
+        isTimeout = trueValue;
+        doAbort();
+      }, timeout);
+    }
+
+    // If a signal is passed in, listen for its abort signal.
+    let externalAbortHandler: (() => void) | null = null;
+    const externalSignal = adapterConfig.signal;
+    if (externalSignal) {
+      if (externalSignal.aborted) {
+        doAbort();
+      } else {
+        externalAbortHandler = () => doAbort();
+        externalSignal.addEventListener('abort', externalAbortHandler, { once: true });
+      }
+    }
+
     // When the content type is not set and the data is not a form data object, the content type is set to application/json by default.
     if (!isContentTypeSet && !isFormData) {
       headers['Content-Type'] = 'application/json; charset=UTF-8';
@@ -50,23 +88,12 @@ export default function adapterFetch(
       body: isBodyData(data) ? data : JSONStringify(data)
     });
 
-    // If the interruption time is set, the request will be interrupted after the specified time.
-    let abortTimer: NodeJS.Timeout | number;
-    let isTimeout = falseValue;
-    if (timeout > 0) {
-      abortTimer = setTimeoutFn(() => {
-        isTimeout = trueValue;
-        ctrl.abort();
-      }, timeout);
-    }
+    fetchPromise.finally(cleanup);
 
     return {
       response: () =>
         fetchPromise.then(
           response => {
-            // Clear interrupt processing after successful request
-            clearTimeoutTimer(abortTimer);
-
             // Response's readable can only be read once and needs to be cloned before it can be reused.
             return response.clone();
           },
@@ -116,10 +143,7 @@ export default function adapterFetch(
         );
       },
       /* c8 ignore stop */
-      abort: () => {
-        ctrl.abort();
-        clearTimeoutTimer(abortTimer);
-      }
+      abort: doAbort
     };
   };
 }


### PR DESCRIPTION
<!--
  Please read the Contribution Guidelines first.
  请务阅读贡献者指南:
  https://alova.js.org/contributing/overview
-->

**相关 Issue / Related Issue**

[843]

<!-- 请注意，我们不接受未经确认的 PR 提交。 / We do not accept PR without confirmation. -->

**这个 PR 是什么类型？/ What type of PR is this?**

<!-- (将 "[ ]" 替换为 "[x]" 即可勾选) -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 至少选择一个 / Choose at least one -->

- [x] 错误修复 (Bug Fix)
- [ ] 新功能 (Feature)
- [ ] 代码重构 (Refactor)
- [ ] TypeScript 类型定义修改 (Typings)
- [ ] 文档修改 (Docs)
- [ ] 代码风格更新 (Code style update)
- [ ] 其他，请描述 (Other, please describe):

**这个 PR 做了什么？/ What does this PR do?**
在adapterFetch里，对传入的signal进行listen，当传入的signal abort时，中止请求

**文档 / Docs**

[此次 PR 的文档 / Docs for this PR]

**测试 / Testing**

<!-- 别忘记测试！ npm run test -->
<!-- Don't forget to test! npm run test -->

[描述测试结果 / Describe the test results.]
